### PR TITLE
Excluding .ruff_cache and .pytest_cache in data science folder

### DIFF
--- a/datascience/.gitignore
+++ b/datascience/.gitignore
@@ -11,3 +11,9 @@ __pycache__/
 
 # Ignore coverage file
 .coverage
+
+# Ruff stuff:
+.ruff_cache/
+
+# pytest stuff
+.pytest_cache/


### PR DESCRIPTION
## Description
Adds exclusion to .gitignore for .ruff_cahce and .pytest_cache

## Related Issue / Task
Mirrors similar fix in the GIS folder


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [ ] Backend
- [X] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] My code follows the project’s style guidelines (linting & formatting)
- [X] This PR is based on the latest `upstream/master`
- [X] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
