### PR TITLE
Add Product Owner dataset data dictionary

### DIFF
--- a/datascience/docs/Data-Dictionary-PO-Datasets.md
+++ b/datascience/docs/Data-Dictionary-PO-Datasets.md
@@ -1,6 +1,6 @@
 # Data Dictionary for Product Owner Datasets
 
-This document provides an overview of the datasets supplied by the Product Owners. It describes the purpose of each file and outlines the associated data schema, including column names, data types, units, and requirements. All datasets referenced in this document are stored in Microsoft Teams > Planting Optimisation Tool > Shared > Datasets.
+This document provides an overview of the datasets supplied by the Product Owners. It describes the purpose of each file and outlines the associated data schema, including column names, data types, units, and requirements. All datasets referenced in this document are stored in Microsoft Teams > Planting Optimisation Tool > Shared > Datasets. The information herein was verified by the Product Owner as accurate at the time of publication (23 January 2026) and represents the current state of the product.
 
 **Note:** Some filenames include a date and a unique identifier.
 


### PR DESCRIPTION
## Description
This PR adds a data dictionary that describes all datasets provided by the Product Owners and is located under datascience/docs.

## Related Issue / Task
PO datasets data dictionary 

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [ ] Backend
- [x] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (Documentation):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
This data dictionary is primarily for onboarding incoming students, helping them understand and work with Product Owner datasets in the Data Science workflow.
