### PR TITLE
Adding workflow for cascading assignment of user story

### DIFF
--- a/.github/workflows/cascading-assignment.yml
+++ b/.github/workflows/cascading-assignment.yml
@@ -1,0 +1,64 @@
+name: Cascade Assignment to Sub-Issues
+
+on:
+  issues:
+    types: [assigned, unassigned]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-sub-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cascade assignment/unassignment to sub-issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          ASSIGNEE: ${{ github.event.assignee.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # Fetch sub-issues via GraphQL
+          SUB_ISSUES=$(gh api graphql \
+            -H "GraphQL-Features: sub_issues" \
+            -f query='
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    subIssues(first: 50) {
+                      nodes {
+                        number
+                      }
+                    }
+                  }
+                }
+              }
+            ' \
+            -f id="$ISSUE_NODE_ID" \
+            --jq '.data.node.subIssues.nodes[].number')
+
+          if [ -z "$SUB_ISSUES" ]; then
+            echo "No sub-issues found for issue #$ISSUE_NUMBER"
+            exit 0
+          fi
+
+          echo "Found sub-issues: $SUB_ISSUES"
+
+          for SUB_ISSUE_NUMBER in $SUB_ISSUES; do
+            if [ "$EVENT_ACTION" = "assigned" ]; then
+              echo "Assigning sub-issue #$SUB_ISSUE_NUMBER to $ASSIGNEE"
+              gh api \
+                --method POST \
+                repos/$REPO_OWNER/$REPO_NAME/issues/$SUB_ISSUE_NUMBER/assignees \
+                -f "assignees[]=$ASSIGNEE"
+            elif [ "$EVENT_ACTION" = "unassigned" ]; then
+              echo "Unassigning $ASSIGNEE from sub-issue #$SUB_ISSUE_NUMBER"
+              gh api \
+                --method DELETE \
+                repos/$REPO_OWNER/$REPO_NAME/issues/$SUB_ISSUE_NUMBER/assignees \
+                -f "assignees[]=$ASSIGNEE"
+            fi
+          done


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
This PR adds a workflow file that will run when a user story is assigned to a collaborator.
When the user story is assigned, the workflow file _should_ run and assign the sub-tasks to the same person.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
This PR applies to all upcoming tasks for the trimester.

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [ ] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [x] Other (please specify): All

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
