### PR TITLE
Adding testing and ratelimit workaround for backend ci pytest

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -118,7 +118,6 @@ jobs:
       run: |
         export DATABASE_URL="postgresql+asyncpg://postgres:devpassword@localhost:5432/pot_test_db"
         export TESTING=true
-        export RATELIMIT_ENABLED=false
         uv run pytest
 
     - name: Fetch base branch and check for backend changes

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -117,6 +117,8 @@ jobs:
     - name: Test with pytest
       run: |
         export DATABASE_URL="postgresql+asyncpg://postgres:devpassword@localhost:5432/pot_test_db"
+        export TESTING=true
+        export RATELIMIT_ENABLED=false
         uv run pytest
 
     - name: Fetch base branch and check for backend changes


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
This PR adds `TESTING=true` to the backend CI pytest step to suppress SMTP connections during testing (So the CI won't fail)

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
This relates to the changes made in #388 

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
