### PR TITLE
US-059/verify email fix

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           sed 's|^SF:|SF:frontend/|' frontend/coverage/lcov.info > /tmp/coverage-fixed.lcov
           diff-cover /tmp/coverage-fixed.lcov --compare-branch=origin/master --format markdown:diff-coverage-frontend.md
+          awk '/^## frontend\//{exit} {print}' diff-coverage-frontend.md > /tmp/stripped.md && mv /tmp/stripped.md diff-coverage-frontend.md
 
       - name: Save PR number
         if: github.event_name == 'pull_request'

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -127,6 +127,7 @@ async def register_user(request: Request, user: UserCreate, db: AsyncSession = D
         subject="Verify your account",
         recipient=db_user.email,
         body=f"Click this link to verify your account:\n{verification_link}",
+        html_body=f'<p>Click this link to verify your account:</p><p><a href="{verification_link}">{verification_link}</a></p>',
     )
 
     return {"message": "User registered. Verification email sent."}

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -6,12 +6,14 @@ from src.config import settings
 
 
 # Private sync function that handles SMTP
-def _send_email_sync(subject: str, recipient: str, body: str) -> None:
+def _send_email_sync(subject: str, recipient: str, body: str, html_body: str | None = None) -> None:
     message = EmailMessage()
     message["Subject"] = subject
     message["From"] = settings.smtp_from_email
     message["To"] = recipient
     message.set_content(body)
+    if html_body:
+        message.add_alternative(html_body, subtype="html")
 
     with smtplib.SMTP(settings.smtp_host, settings.smtp_port) as server:
         server.starttls()
@@ -20,9 +22,9 @@ def _send_email_sync(subject: str, recipient: str, body: str) -> None:
 
 
 # Async function that offloads to thread pool to prevent blocking
-async def send_email(subject: str, recipient: str, body: str) -> None:
+async def send_email(subject: str, recipient: str, body: str, html_body: str | None = None) -> None:
     if settings.TESTING:
         print(f"TEST EMAIL to {recipient} | {subject} | {body}")
         return
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _send_email_sync, subject, recipient, body)
+    await loop.run_in_executor(None, _send_email_sync, subject, recipient, body, html_body)

--- a/frontend/docs/verify_email_diagram.md
+++ b/frontend/docs/verify_email_diagram.md
@@ -1,0 +1,40 @@
+```mermaid
+sequenceDiagram
+    participant User
+    participant Email as Email Client
+    participant FE as Frontend (React)
+    participant BE as Backend (FastAPI)
+    participant DB as Database
+    participant SMTP as Brevo (SMTP)
+
+    User->>FE: Submit registration form
+    FE->>BE: POST /auth/register (name, email, password, role)
+    BE->>DB: INSERT user (is_verified=false)
+    DB-->>BE: user row
+    BE->>DB: INSERT auth_token (type=email_verification, expires=10min)
+    DB-->>BE: token row
+    BE->>SMTP: Send verification email with link
+    SMTP-->>Email: Deliver email
+    BE-->>FE: 200 Registration successful
+    FE-->>User: "Check your inbox" success screen
+
+    User->>Email: Click verification link
+    Email->>FE: GET /verify-email?token=abc123
+    FE->>BE: POST /auth/verify-email (token=abc123)
+    BE->>DB: SELECT auth_token WHERE hash=hash(abc123) AND used_at IS NULL AND expires_at > now
+    DB-->>BE: token row
+    BE->>DB: UPDATE user SET is_verified=true
+    BE->>DB: UPDATE auth_token SET used_at=now
+    DB-->>BE: ok
+    BE-->>FE: 200 Email verified successfully
+    FE-->>User: "Email verified!" success screen with Sign in link
+
+    User->>FE: Click Sign in
+    FE->>BE: POST /auth/token (email, password)
+    BE->>DB: SELECT user WHERE email matches
+    DB-->>BE: user row (is_verified=true)
+    BE->>BE: verify password hash
+    BE->>BE: create JWT (sub, role, exp)
+    BE-->>FE: access_token
+    FE-->>User: Redirect to home page
+```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import SpeciesPage from "./pages/SpeciesPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import LoginPage from "./pages/auth/LoginPage";
 import RegisterPage from "./pages/auth/RegisterPage";
+import VerifyEmailPage from "./pages/auth/VerifyEmailPage";
 import AdminLayout from "./components/layout/AdminLayout";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import AdminSettings from "./pages/admin/AdminSettings";
@@ -31,6 +32,7 @@ export default function App() {
           <Routes>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/verify-email" element={<VerifyEmailPage />} />
             <Route element={<MainLayout />}>
               <Route path="/" index element={<HomePage />} />
               <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/hooks/useVerifyEmail.ts
+++ b/frontend/src/hooks/useVerifyEmail.ts
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_URL;
+
+type VerifyStatus = "loading" | "success" | "error";
+
+export function useVerifyEmail() {
+  const [status, setStatus] = useState<VerifyStatus>("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const verify = async (token: string) => {
+    setStatus("loading");
+    setErrorMessage("");
+
+    try {
+      const response = await fetch(`${API_BASE}/auth/verify-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+
+      if (!response.ok) {
+        let errorText = "Invalid or expired verification link.";
+        try {
+          const data = await response.json();
+          errorText = data.detail || errorText;
+        } catch {
+          // keep default
+        }
+        throw new Error(errorText);
+      }
+
+      setStatus("success");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Verification failed. Please try again."
+      );
+      setStatus("error");
+    }
+  };
+
+  return { status, errorMessage, verify };
+}

--- a/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -14,7 +14,6 @@ function VerifyEmailPage() {
       hasVerified.current = true;
       verify(token);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,71 @@
+import { Helmet } from "react-helmet-async";
+import { useEffect, useRef } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useVerifyEmail } from "../../hooks/useVerifyEmail";
+
+function VerifyEmailPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const { status, errorMessage, verify } = useVerifyEmail();
+  const hasVerified = useRef(false);
+
+  useEffect(() => {
+    if (token && !hasVerified.current) {
+      hasVerified.current = true;
+      verify(token);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <title>Verify Email | Planting Optimisation Tool</title>
+      </Helmet>
+
+      <main className="login-page">
+        <section className="login-card">
+          {!token ? (
+            <div className="register-success">
+              <div className="register-success-icon verify-email-icon--error">&#10007;</div>
+              <h1 className="login-title">Invalid link</h1>
+              <p className="register-success-body">
+                This verification link is missing a token. Please use the link from your verification email.
+              </p>
+              <Link to="/login" className="login-submit-btn register-success-link">
+                Back to sign in
+              </Link>
+            </div>
+          ) : status === "loading" ? (
+            <div className="register-success">
+              <h1 className="login-title">Verifying your email...</h1>
+              <p className="register-success-body">Please wait a moment.</p>
+            </div>
+          ) : status === "success" ? (
+            <div className="register-success">
+              <div className="register-success-icon">&#10003;</div>
+              <h1 className="login-title">Email verified!</h1>
+              <p className="register-success-body">
+                Your account has been activated. You can now sign in.
+              </p>
+              <Link to="/login" className="login-submit-btn register-success-link">
+                Sign in
+              </Link>
+            </div>
+          ) : (
+            <div className="register-success">
+              <div className="register-success-icon verify-email-icon--error">&#10007;</div>
+              <h1 className="login-title">Verification failed</h1>
+              <p className="register-success-body">{errorMessage}</p>
+              <Link to="/login" className="login-submit-btn register-success-link">
+                Back to sign in
+              </Link>
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default VerifyEmailPage;

--- a/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -27,12 +27,18 @@ function VerifyEmailPage() {
         <section className="login-card">
           {!token ? (
             <div className="register-success">
-              <div className="register-success-icon verify-email-icon--error">&#10007;</div>
+              <div className="register-success-icon verify-email-icon--error">
+                &#10007;
+              </div>
               <h1 className="login-title">Invalid link</h1>
               <p className="register-success-body">
-                This verification link is missing a token. Please use the link from your verification email.
+                This verification link is missing a token. Please use the link
+                from your verification email.
               </p>
-              <Link to="/login" className="login-submit-btn register-success-link">
+              <Link
+                to="/login"
+                className="login-submit-btn register-success-link"
+              >
                 Back to sign in
               </Link>
             </div>
@@ -48,16 +54,24 @@ function VerifyEmailPage() {
               <p className="register-success-body">
                 Your account has been activated. You can now sign in.
               </p>
-              <Link to="/login" className="login-submit-btn register-success-link">
+              <Link
+                to="/login"
+                className="login-submit-btn register-success-link"
+              >
                 Sign in
               </Link>
             </div>
           ) : (
             <div className="register-success">
-              <div className="register-success-icon verify-email-icon--error">&#10007;</div>
+              <div className="register-success-icon verify-email-icon--error">
+                &#10007;
+              </div>
               <h1 className="login-title">Verification failed</h1>
               <p className="register-success-body">{errorMessage}</p>
-              <Link to="/login" className="login-submit-btn register-success-link">
+              <Link
+                to="/login"
+                className="login-submit-btn register-success-link"
+              >
                 Back to sign in
               </Link>
             </div>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1383,6 +1383,11 @@ main.container {
   width: 64px;
 }
 
+.verify-email-icon--error {
+  background: #fef2f2;
+  color: #dc2626;
+}
+
 .register-success-body {
   color: var(--muted);
   font-size: 0.95rem;

--- a/frontend/src/test/useVerifyEmail.test.ts
+++ b/frontend/src/test/useVerifyEmail.test.ts
@@ -1,0 +1,93 @@
+// useVerifyEmail.test.ts
+//
+// Tests for the useVerifyEmail hook in isolation.
+//
+// Strategy: mock the global fetch so we control what the API returns,
+// then assert that the hook updates its status correctly.
+// The component that calls this hook is tested separately in verifyEmailPage.test.tsx.
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useVerifyEmail } from "../hooks/useVerifyEmail";
+
+describe("useVerifyEmail", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("starts in loading state with no error message", () => {
+    const { result } = renderHook(() => useVerifyEmail());
+
+    expect(result.current.status).toBe("loading");
+    expect(result.current.errorMessage).toBe("");
+  });
+
+  it("sets status to success when verification succeeds", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: "Email verified successfully" }),
+    } as Response);
+
+    const { result } = renderHook(() => useVerifyEmail());
+
+    await act(async () => {
+      await result.current.verify("valid-token");
+    });
+
+    expect(result.current.status).toBe("success");
+    expect(result.current.errorMessage).toBe("");
+  });
+
+  it("sets status to error with backend detail when token is invalid or expired", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ detail: "Invalid or expired token" }),
+    } as Response);
+
+    const { result } = renderHook(() => useVerifyEmail());
+
+    await act(async () => {
+      await result.current.verify("expired-token");
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.errorMessage).toBe("Invalid or expired token");
+  });
+
+  it("sets a fallback errorMessage when the backend returns no detail field", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useVerifyEmail());
+
+    await act(async () => {
+      await result.current.verify("token");
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.errorMessage).toBe(
+      "Invalid or expired verification link."
+    );
+  });
+
+  it("sets a fallback errorMessage when fetch throws a network error", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useVerifyEmail());
+
+    await act(async () => {
+      await result.current.verify("token");
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.errorMessage).toBe("Network error");
+  });
+});

--- a/frontend/src/test/verifyEmailPage.test.tsx
+++ b/frontend/src/test/verifyEmailPage.test.tsx
@@ -20,7 +20,10 @@ vi.mock("../hooks/useVerifyEmail", () => ({
 }));
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom"
+    );
   return {
     ...actual,
     useSearchParams: vi.fn(),
@@ -52,13 +55,18 @@ describe("VerifyEmailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useVerifyEmail).mockReturnValue(defaultHookReturn);
-    vi.mocked(useSearchParams).mockReturnValue([new URLSearchParams("token=abc123"), vi.fn()]);
+    vi.mocked(useSearchParams).mockReturnValue([
+      new URLSearchParams("token=abc123"),
+      vi.fn(),
+    ]);
   });
 
   it("shows loading state while verifying", () => {
     renderPage();
 
-    expect(screen.getByRole("heading", { name: /verifying your email/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /verifying your email/i })
+    ).toBeInTheDocument();
     expect(screen.getByText(/please wait/i)).toBeInTheDocument();
   });
 
@@ -76,9 +84,16 @@ describe("VerifyEmailPage", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: /email verified/i })).toBeInTheDocument();
-    expect(screen.getByText(/your account has been activated/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute("href", "/login");
+    expect(
+      screen.getByRole("heading", { name: /email verified/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/your account has been activated/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
   });
 
   it("shows error state when verification fails", () => {
@@ -90,18 +105,31 @@ describe("VerifyEmailPage", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: /verification failed/i })).toBeInTheDocument();
-    expect(screen.getByText("Invalid or expired verification link.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /back to sign in/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /verification failed/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Invalid or expired verification link.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to sign in/i })
+    ).toBeInTheDocument();
   });
 
   it("shows invalid link state and does not call verify when no token in URL", () => {
-    vi.mocked(useSearchParams).mockReturnValue([new URLSearchParams(""), vi.fn()]);
+    vi.mocked(useSearchParams).mockReturnValue([
+      new URLSearchParams(""),
+      vi.fn(),
+    ]);
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: /invalid link/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /back to sign in/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /invalid link/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to sign in/i })
+    ).toBeInTheDocument();
     expect(mockVerify).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/test/verifyEmailPage.test.tsx
+++ b/frontend/src/test/verifyEmailPage.test.tsx
@@ -1,0 +1,107 @@
+// verifyEmailPage.test.tsx
+//
+// Tests for the VerifyEmailPage UI component.
+//
+// Strategy: mock the useVerifyEmail hook and useSearchParams so this test
+// file only cares about what the component renders for each status state.
+// The hook's own behaviour (fetch calls, API errors) is tested separately
+// in useVerifyEmail.test.ts.
+
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+
+import VerifyEmailPage from "../pages/auth/VerifyEmailPage";
+
+vi.mock("../hooks/useVerifyEmail", () => ({
+  useVerifyEmail: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useSearchParams: vi.fn(),
+  };
+});
+
+import { useVerifyEmail } from "../hooks/useVerifyEmail";
+import { useSearchParams } from "react-router-dom";
+
+const mockVerify = vi.fn();
+
+const defaultHookReturn = {
+  status: "loading" as const,
+  errorMessage: "",
+  verify: mockVerify,
+};
+
+function renderPage() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <VerifyEmailPage />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe("VerifyEmailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useVerifyEmail).mockReturnValue(defaultHookReturn);
+    vi.mocked(useSearchParams).mockReturnValue([new URLSearchParams("token=abc123"), vi.fn()]);
+  });
+
+  it("shows loading state while verifying", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: /verifying your email/i })).toBeInTheDocument();
+    expect(screen.getByText(/please wait/i)).toBeInTheDocument();
+  });
+
+  it("calls verify with the token on mount", () => {
+    renderPage();
+
+    expect(mockVerify).toHaveBeenCalledWith("abc123");
+  });
+
+  it("shows success state after verification", () => {
+    vi.mocked(useVerifyEmail).mockReturnValue({
+      ...defaultHookReturn,
+      status: "success",
+    });
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: /email verified/i })).toBeInTheDocument();
+    expect(screen.getByText(/your account has been activated/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute("href", "/login");
+  });
+
+  it("shows error state when verification fails", () => {
+    vi.mocked(useVerifyEmail).mockReturnValue({
+      ...defaultHookReturn,
+      status: "error",
+      errorMessage: "Invalid or expired verification link.",
+    });
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: /verification failed/i })).toBeInTheDocument();
+    expect(screen.getByText("Invalid or expired verification link.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to sign in/i })).toBeInTheDocument();
+  });
+
+  it("shows invalid link state and does not call verify when no token in URL", () => {
+    vi.mocked(useSearchParams).mockReturnValue([new URLSearchParams(""), vi.fn()]);
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: /invalid link/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to sign in/i })).toBeInTheDocument();
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
This PR adds:
- verify-email page and route introduced
- useVerifyEmail hook to handle API call, useRef guard against idempotency (verification is a one-time action)
- backend/src/services/email_service.py send_email now sends html in email verification
- backend/src/routers/auth.py sends html template to match rather than raw text (clickable link now)
- diagram added for flow
- tests added

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Linked to #444 

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
