### PR TITLE
US014/Farm-environmental-profile-UI-clean

### DIFF
--- a/frontend/src/components/profile/profileAllCards.tsx
+++ b/frontend/src/components/profile/profileAllCards.tsx
@@ -1,0 +1,86 @@
+import { Farm } from "@/hooks/useUserProfiles";
+
+interface FarmCardProps {
+  farm: Farm;
+}
+
+// Create farm card that parses data from backend to be displayed in the frontend
+export default function FarmCard({ farm }: FarmCardProps) {
+  // Convert boolean tags to strings to be displayed
+  const tags = [
+    farm.coastal && "Coastal",
+    farm.riparian && "Riparian",
+    farm.nitrogen_fixing && "Nitrogen Fixing",
+    farm.shade_tolerant && "Shade Tolerant",
+    farm.bank_stabilising && "Bank Stabilising",
+  ].filter(Boolean) as string[];
+
+  return (
+    <div className="farmCard">
+      <div className="farmCardHeader">
+        <span className="farmCardId">Farm #{farm.id}</span>
+        <span className="farmCardArea">
+          {Number(farm.area_ha).toFixed(3)} ha
+        </span>
+      </div>
+
+      <div className="farmCardGrid">
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Rainfall</span>
+          <span className="farmCardStatValue">{farm.rainfall_mm} mm</span>
+        </div>
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Temperature</span>
+          <span className="farmCardStatValue">
+            {farm.temperature_celsius}°C
+          </span>
+        </div>
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Elevation</span>
+          <span className="farmCardStatValue">{farm.elevation_m} m</span>
+        </div>
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Soil pH</span>
+          <span className="farmCardStatValue">
+            {farm.ph ? Number(farm.ph).toFixed(1) : "N/A"}
+          </span>
+        </div>
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Slope</span>
+          <span className="farmCardStatValue">
+            {farm.slope ? Number(farm.slope).toFixed(2) : "N/A"}°
+          </span>
+        </div>
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Soil Type</span>
+          <span className="farmCardStatValue">{farm.soil_texture.name}</span>
+        </div>
+      </div>
+
+      <div className="farmCardCoords">
+        📍 {Number(farm.latitude).toFixed(5)},{" "}
+        {Number(farm.longitude).toFixed(5)}
+      </div>
+
+      {farm.agroforestry_type.length > 0 && (
+        <div className="farmCardTags">
+          {farm.agroforestry_type.map(type => (
+            <span key={type.name} className="farmTag farmTagAgroforestry">
+              {type.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {tags.length > 0 && (
+        <div className="farmCardTags">
+          {tags.map(tag => (
+            <span key={tag} className="farmTag farmTagTrait">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profileEditButtons.tsx
+++ b/frontend/src/components/profile/profileEditButtons.tsx
@@ -1,0 +1,48 @@
+import { useAuth } from "@/contexts/AuthContext";
+
+interface ProfileEditProps {
+  onAdd?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export default function ProfileEditActions({
+  onAdd,
+  onEdit,
+  onDelete,
+}: ProfileEditProps) {
+  // Call user details from context
+  const { user } = useAuth();
+
+  // If user exists, show add button, if user is supervisor or above, show edit button
+  // If use admin is admin show delete button, component is non-functional and currently
+  // Cosmetic
+  const canAdd = !!user;
+  const canEdit = user?.role === "supervisor" || user?.role === "admin";
+  const canDelete = user?.role === "admin";
+
+  if (!canAdd && !canEdit && !canDelete) return null;
+
+  return (
+    <div className="farmActions">
+      {canDelete && (
+        <button
+          className="farmActionBtn farmActionBtnDanger"
+          onClick={onDelete}
+        >
+          🗑️ Delete
+        </button>
+      )}
+      {canEdit && (
+        <button className="farmActionBtn" onClick={onEdit}>
+          ✏️ Edit
+        </button>
+      )}
+      {canAdd && (
+        <button className="farmActionBtn" onClick={onAdd}>
+          ➕ Add
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profileEditButtons.tsx
+++ b/frontend/src/components/profile/profileEditButtons.tsx
@@ -14,11 +14,10 @@ export default function ProfileEditActions({
   // Call user details from context
   const { user } = useAuth();
 
-  // If user exists, show add button, if user is supervisor or above, show edit button
-  // If use admin is admin show delete button, component is non-functional and currently
-  // Cosmetic
-  const canAdd = !!user;
+  // Officer role cannot add, edit or delete, supervisor can read and edit
+  // If user is admin show all post buttons, component is non-functional and currently cosmetic
   const canEdit = user?.role === "supervisor" || user?.role === "admin";
+  const canAdd = user?.role === "admin";
   const canDelete = user?.role === "admin";
 
   if (!canAdd && !canEdit && !canDelete) return null;

--- a/frontend/src/components/profile/profileFarms.tsx
+++ b/frontend/src/components/profile/profileFarms.tsx
@@ -1,0 +1,63 @@
+import FarmCard from "./profileAllCards";
+import FarmPageNav from "./profilePageNav";
+import ProfileEditActions from "./profileEditButtons";
+import { Farm } from "@/hooks/useUserProfiles";
+
+interface FarmListProps {
+  farms: Farm[];
+  isLoading: boolean;
+  user: { name: string } | null;
+  page: number;
+  totalPages: number;
+  setPage: (page: number) => void;
+}
+
+export default function FarmList({
+  farms,
+  isLoading,
+  user,
+  page,
+  totalPages,
+  setPage,
+}: FarmListProps) {
+  if (isLoading) {
+    return <p className="farmListEmpty">Loading farms...</p>;
+  }
+
+  // Not logged in
+  if (!user) {
+    return (
+      <p className="farmListEmpty">
+        You need to be logged in to see your farms.
+      </p>
+    );
+  }
+
+  // Logged in but no farms still displays editing actions dependent on role
+  if (farms.length === 0) {
+    return (
+      <>
+        <p className="farmListEmpty">No farms found.</p>
+        <div className="farmBottomRow">
+          <ProfileEditActions />
+        </div>
+      </>
+    );
+  }
+
+  // Logged in with farms displays all data
+  return (
+    <div>
+      <div className="farmList">
+        {farms.map(farm => (
+          <FarmCard key={farm.id} farm={farm} />
+        ))}
+      </div>
+
+      <div className="farmBottomRow">
+        <FarmPageNav page={page} totalPages={totalPages} setPage={setPage} />
+        <ProfileEditActions />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profileHeader.tsx
+++ b/frontend/src/components/profile/profileHeader.tsx
@@ -1,0 +1,22 @@
+// Create interface to set types for ProfileHeaderProps
+interface FarmProfileHeaderProps {
+  farmerName?: string;
+  farmCount: number;
+}
+
+// Display ProfileHeader as a page header for the farmer's environmental profile
+export default function ProfileHeader({
+  farmerName,
+  farmCount,
+}: FarmProfileHeaderProps) {
+  return (
+    <header className="farmProfileHeader">
+      <h1 className="farmProfileTitle">Environmental Profile</h1>
+      <p className="farmProfileSubtitle">
+        {farmerName
+          ? `${farmerName} · ${farmCount} ${farmCount === 1 ? "Farm" : "Farms"}`
+          : ""}
+      </p>
+    </header>
+  );
+}

--- a/frontend/src/components/profile/profileHeader.tsx
+++ b/frontend/src/components/profile/profileHeader.tsx
@@ -1,20 +1,20 @@
 // Create interface to set types for ProfileHeaderProps
 interface FarmProfileHeaderProps {
-  farmerName?: string;
+  userName?: string;
   farmCount: number;
 }
 
-// Display ProfileHeader as a page header for the farmer's environmental profile
+// Display ProfileHeader as a page header for the user's environmental profile
 export default function ProfileHeader({
-  farmerName,
+  userName,
   farmCount,
 }: FarmProfileHeaderProps) {
   return (
     <header className="farmProfileHeader">
       <h1 className="farmProfileTitle">Environmental Profile</h1>
       <p className="farmProfileSubtitle">
-        {farmerName
-          ? `${farmerName} · ${farmCount} ${farmCount === 1 ? "Farm" : "Farms"}`
+        {userName
+          ? `${userName} · ${farmCount} ${farmCount === 1 ? "Farm" : "Farms"}`
           : ""}
       </p>
     </header>

--- a/frontend/src/components/profile/profilePageNav.tsx
+++ b/frontend/src/components/profile/profilePageNav.tsx
@@ -1,0 +1,36 @@
+interface FarmPageNavProps {
+  page: number;
+  totalPages: number;
+  setPage: (page: number) => void;
+}
+
+export default function FarmPageNav({
+  page,
+  totalPages,
+  setPage,
+}: FarmPageNavProps) {
+  return (
+    <div>
+      <div className="farmPageNav">
+        {/* Create buttons for setting current page to next or before current page */}
+        <button
+          className="farmPageNavBtn"
+          disabled={page === 0}
+          onClick={() => setPage(page - 1)}
+        >
+          ← Previous
+        </button>
+        <span className="farmPageNavInfo">
+          Page {page + 1} of {totalPages}
+        </span>
+        <button
+          className="farmPageNavBtn"
+          disabled={page >= totalPages - 1}
+          onClick={() => setPage(page + 1)}
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profileSearchInput.tsx
+++ b/frontend/src/components/profile/profileSearchInput.tsx
@@ -1,0 +1,31 @@
+interface FarmSearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+  isLoading: boolean;
+}
+
+export default function FarmSearchInput({
+  value,
+  onChange,
+  onClear,
+  isLoading,
+}: FarmSearchInputProps) {
+  return (
+    <div className="profile-search">
+      <input
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        disabled={isLoading}
+        className="search-input"
+        placeholder="Search by farm ID..."
+      />
+
+      {value && (
+        <button onClick={onClear} className="farmPageNavBtn">
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profileSearchPanel.tsx
+++ b/frontend/src/components/profile/profileSearchPanel.tsx
@@ -22,8 +22,8 @@ export default function FarmSearchPanel({
 }: FarmSearchPanelProps) {
   const handleClear = () => setQuery("");
 
-  const isSearching = (query).trim().length > 0; 
-  
+  const isSearching = query.trim().length > 0;
+
   return (
     <>
       <FarmSearchInput

--- a/frontend/src/components/profile/profileSearchPanel.tsx
+++ b/frontend/src/components/profile/profileSearchPanel.tsx
@@ -1,0 +1,64 @@
+import FarmSearchInput from "./profileSearchInput";
+import EnvironmentalProfileCard from "./profileSearchedCard";
+import ProfileEditActions from "./profileEditButtons";
+import { EnvironmentalProfile } from "@/hooks/useSearchProfiles";
+
+interface FarmSearchPanelProps {
+  query: string;
+  setQuery: (q: string) => void;
+  profile: EnvironmentalProfile | null;
+  isLoading: boolean;
+  error: string | null;
+  user: { name: string } | null;
+}
+
+export default function FarmSearchPanel({
+  query,
+  setQuery,
+  profile,
+  isLoading,
+  error,
+  user,
+}: FarmSearchPanelProps) {
+  const handleClear = () => {
+    setQuery("");
+  };
+
+  const isSearching = query.trim().length > 0;
+
+  return (
+    <>
+      <FarmSearchInput
+        value={query}
+        onChange={setQuery}
+        onClear={handleClear}
+        isLoading={isLoading}
+      />
+
+      {error && <p className="farmListEmpty">{error}</p>}
+
+      {isSearching && isLoading && (
+        <p className="farmListEmpty">Loading profile...</p>
+      )}
+
+      {isSearching && !isLoading && profile && (
+        <div>
+          <EnvironmentalProfileCard profile={profile} />
+
+          <div className="farmBottomRow">
+            <ProfileEditActions />
+          </div>
+        </div>
+      )}
+
+      {isSearching && !isLoading && !profile && !error && (
+        <>
+          {!user && (
+            <p className="farmListEmpty">You must be logged in to search.</p>
+          )}
+          {user && <p className="farmListEmpty">No profile found.</p>}
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/profile/profileSearchPanel.tsx
+++ b/frontend/src/components/profile/profileSearchPanel.tsx
@@ -20,12 +20,10 @@ export default function FarmSearchPanel({
   error,
   user,
 }: FarmSearchPanelProps) {
-  const handleClear = () => {
-    setQuery("");
-  };
+  const handleClear = () => setQuery("");
 
-  const isSearching = query.trim().length > 0;
-
+  const isSearching = (query).trim().length > 0; 
+  
   return (
     <>
       <FarmSearchInput

--- a/frontend/src/components/profile/profileSearchedCard.tsx
+++ b/frontend/src/components/profile/profileSearchedCard.tsx
@@ -1,0 +1,66 @@
+import { EnvironmentalProfile } from "@/hooks/useSearchProfiles";
+
+interface Props {
+  profile: EnvironmentalProfile;
+}
+
+export default function EnvironmentalProfileCard({ profile }: Props) {
+  const toNumber = (value: unknown) =>
+    value !== null && value !== undefined ? Number(value) : null;
+
+  return (
+    <div className="profileCard">
+      <div className="farmCardHeader">
+        <span className="farmCardId">Farm #{profile.id}</span>
+        {profile.area_ha != null && (
+          <span className="farmCardArea">
+            {Number(profile.area_ha).toFixed(3)} ha
+          </span>
+        )}
+      </div>
+
+      <div className="farmCardGrid">
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Elevation</span>
+          <span className="farmCardStatValue">
+            {profile.elevation_m ?? "N/A"} m
+          </span>
+        </div>
+
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Soil pH</span>
+          <span className="farmCardStatValue">
+            {profile.ph != null ? toNumber(profile.ph)?.toFixed(1) : "N/A"}
+          </span>
+        </div>
+
+        <div className="farmCardStat">
+          <span className="farmCardStatLabel">Slope</span>
+          <span className="farmCardStatValue">
+            {profile.slope != null
+              ? toNumber(profile.slope)?.toFixed(2)
+              : "N/A"}
+            °
+          </span>
+        </div>
+      </div>
+
+      <div className="farmCardCoords">
+        📍{" "}
+        {profile.latitude != null
+          ? toNumber(profile.latitude)?.toFixed(5)
+          : "N/A"}
+        ,{" "}
+        {profile.longitude != null
+          ? toNumber(profile.longitude)?.toFixed(5)
+          : "N/A"}
+      </div>
+
+      {profile.coastal && (
+        <div className="farmCardTags">
+          <span className="farmTag farmTagTrait">Coastal</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSearchProfiles.ts
+++ b/frontend/src/hooks/useSearchProfiles.ts
@@ -16,21 +16,14 @@ const API_BASE = import.meta.env.VITE_API_URL;
 
 export function useSearchProfiles(query: string) {
   const { getAccessToken } = useAuth();
+  const token = getAccessToken(); 
 
   const [profile, setProfile] = useState<EnvironmentalProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!query.trim()) {
-      setProfile(null);
-      setError(null);
-      return;
-    }
-
-    const token = getAccessToken();
-
-    if (!token) {
+    if (!query.trim() || !token) {
       setProfile(null);
       setError(null);
       return;
@@ -43,7 +36,7 @@ export function useSearchProfiles(query: string) {
       try {
         const res = await fetch(`${API_BASE}/profile/${query}`, {
           headers: {
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${token}`, 
             Accept: "application/json",
           },
         });
@@ -52,36 +45,28 @@ export function useSearchProfiles(query: string) {
           let errorMessage = "Something went wrong";
           try {
             const errorData = await res.json();
-
             if (typeof errorData.detail === "string") {
               errorMessage = errorData.detail;
             }
           } catch {
             errorMessage = await res.text();
           }
-
           throw new Error(errorMessage);
         }
 
         const data = await res.json();
-
         data.id = data.id ?? Number(query);
-
         setProfile(data);
       } catch (err: unknown) {
         setProfile(null);
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError("Unexpected error");
-        }
+        setError(err instanceof Error ? err.message : "Unexpected error");
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchProfile();
-  }, [query, getAccessToken]);
+  }, [query, token]); 
 
   return { profile, isLoading, error };
 }

--- a/frontend/src/hooks/useSearchProfiles.ts
+++ b/frontend/src/hooks/useSearchProfiles.ts
@@ -16,14 +16,21 @@ const API_BASE = import.meta.env.VITE_API_URL;
 
 export function useSearchProfiles(query: string) {
   const { getAccessToken } = useAuth();
-  const token = getAccessToken();
 
   const [profile, setProfile] = useState<EnvironmentalProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token || !query.trim()) {
+    if (!query.trim()) {
+      setProfile(null);
+      setError(null);
+      return;
+    }
+
+    const token = getAccessToken();
+
+    if (!token) {
       setProfile(null);
       setError(null);
       return;
@@ -74,7 +81,7 @@ export function useSearchProfiles(query: string) {
     };
 
     fetchProfile();
-  }, [query, token]);
+  }, [query, getAccessToken]);
 
   return { profile, isLoading, error };
 }

--- a/frontend/src/hooks/useSearchProfiles.ts
+++ b/frontend/src/hooks/useSearchProfiles.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+
+export interface EnvironmentalProfile {
+  id: number;
+  elevation_m: number;
+  ph?: number | string;
+  slope?: number | string;
+  latitude: number | string;
+  longitude: number | string;
+  area_ha?: number | string;
+  coastal?: boolean;
+}
+
+const API_BASE = import.meta.env.VITE_API_URL;
+
+export function useSearchProfiles(query: string) {
+  const { getAccessToken } = useAuth();
+  const token = getAccessToken();
+
+  const [profile, setProfile] = useState<EnvironmentalProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token || !query.trim()) {
+      setProfile(null);
+      setError(null);
+      return;
+    }
+
+    const fetchProfile = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(`${API_BASE}/profile/${query}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+          },
+        });
+
+        if (!res.ok) {
+          let errorMessage = "Something went wrong";
+          try {
+            const errorData = await res.json();
+
+            if (typeof errorData.detail === "string") {
+              errorMessage = errorData.detail;
+            }
+          } catch {
+            errorMessage = await res.text();
+          }
+
+          throw new Error(errorMessage);
+        }
+
+        const data = await res.json();
+
+        data.id = data.id ?? Number(query);
+
+        setProfile(data);
+      } catch (err: unknown) {
+        setProfile(null);
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("Unexpected error");
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [query, token]);
+
+  return { profile, isLoading, error };
+}

--- a/frontend/src/hooks/useSearchProfiles.ts
+++ b/frontend/src/hooks/useSearchProfiles.ts
@@ -16,7 +16,7 @@ const API_BASE = import.meta.env.VITE_API_URL;
 
 export function useSearchProfiles(query: string) {
   const { getAccessToken } = useAuth();
-  const token = getAccessToken(); 
+  const token = getAccessToken();
 
   const [profile, setProfile] = useState<EnvironmentalProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -36,7 +36,7 @@ export function useSearchProfiles(query: string) {
       try {
         const res = await fetch(`${API_BASE}/profile/${query}`, {
           headers: {
-            Authorization: `Bearer ${token}`, 
+            Authorization: `Bearer ${token}`,
             Accept: "application/json",
           },
         });
@@ -66,7 +66,7 @@ export function useSearchProfiles(query: string) {
     };
 
     fetchProfile();
-  }, [query, token]); 
+  }, [query, token]);
 
   return { profile, isLoading, error };
 }

--- a/frontend/src/hooks/useUserProfiles.ts
+++ b/frontend/src/hooks/useUserProfiles.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+
+const API_BASE = import.meta.env.VITE_API_URL;
+
+export interface SoilTexture {
+  name: string;
+}
+export interface AgroforestryType {
+  name: string;
+}
+export interface Farm {
+  id: number;
+  rainfall_mm: number;
+  temperature_celsius: number;
+  elevation_m: number;
+  ph: number;
+  soil_texture: SoilTexture;
+  area_ha: number;
+  latitude: number;
+  longitude: number;
+  coastal: boolean;
+  riparian: boolean;
+  nitrogen_fixing: boolean;
+  shade_tolerant: boolean;
+  bank_stabilising: boolean;
+  slope: number;
+  agroforestry_type: AgroforestryType[];
+}
+
+export function useUserProfiles() {
+  const { getAccessToken } = useAuth();
+  const token = getAccessToken();
+
+  const [allFarms, setAllFarms] = useState<Farm[]>([]);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const PAGE_SIZE = 9;
+
+  useEffect(() => {
+    if (!token) {
+      setError(null);
+      return;
+    }
+
+    const fetchFarms = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(`${API_BASE}/auth/users/me/items`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+          },
+        });
+
+        if (!res.ok) {
+          const errorText = await res.text();
+          throw new Error(errorText || `Failed to fetch farms (${res.status})`);
+        }
+
+        const data = await res.json();
+        setAllFarms(data);
+      } catch (err: unknown) {
+        setAllFarms([]);
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("An unexpected error occurred");
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchFarms();
+  }, [token]);
+
+  const farms = allFarms.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const totalPages = Math.ceil(allFarms.length / PAGE_SIZE);
+
+  return {
+    farms,
+    isLoading,
+    error,
+    page,
+    setPage,
+    totalPages,
+    totalFarms: allFarms.length,
+  };
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import ProfileHeader from "@/components/profile/profileHeader";
 import FarmList from "@/components/profile/profileFarms";
@@ -11,6 +11,15 @@ import { useAuth } from "@/contexts/AuthContext";
 function ProfilePage() {
   const { user } = useAuth();
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [query]);
 
   const { farms, isLoading, page, setPage, totalFarms, totalPages } =
     useUserProfiles();
@@ -19,7 +28,7 @@ function ProfilePage() {
     profile,
     isLoading: isProfileLoading,
     error,
-  } = useSearchProfiles(query);
+  } = useSearchProfiles(debouncedQuery);
 
   const isSearching = query.trim().length > 0;
 
@@ -29,7 +38,7 @@ function ProfilePage() {
         <title>Environmental Profile | Planting Optimisation Tool</title>
       </Helmet>
 
-      <ProfileHeader farmerName={user?.name} farmCount={totalFarms} />
+      <ProfileHeader userName={user?.name} farmCount={totalFarms} />
 
       <FarmSearchPanel
         query={query}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,12 +1,55 @@
+import { useState } from "react";
 import { Helmet } from "react-helmet-async";
+import ProfileHeader from "@/components/profile/profileHeader";
+import FarmList from "@/components/profile/profileFarms";
+import FarmSearchPanel from "@/components/profile/profileSearchPanel";
 
-// TODO: Empty ProfilePage
+import { useUserProfiles } from "../hooks/useUserProfiles";
+import { useSearchProfiles } from "../hooks/useSearchProfiles";
+import { useAuth } from "@/contexts/AuthContext";
+
 function ProfilePage() {
+  const { user } = useAuth();
+  const [query, setQuery] = useState("");
+
+  const { farms, isLoading, page, setPage, totalFarms, totalPages } =
+    useUserProfiles();
+
+  const {
+    profile,
+    isLoading: isProfileLoading,
+    error,
+  } = useSearchProfiles(query);
+
+  const isSearching = query.trim().length > 0;
+
   return (
     <div>
       <Helmet>
         <title>Environmental Profile | Planting Optimisation Tool</title>
       </Helmet>
+
+      <ProfileHeader farmerName={user?.name} farmCount={totalFarms} />
+
+      <FarmSearchPanel
+        query={query}
+        setQuery={setQuery}
+        profile={profile}
+        isLoading={isProfileLoading}
+        error={error}
+        user={user}
+      />
+
+      {!isSearching && (
+        <FarmList
+          farms={farms}
+          isLoading={isLoading}
+          user={user}
+          page={page}
+          totalPages={totalPages}
+          setPage={setPage}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -16,7 +16,7 @@ function ProfilePage() {
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedQuery(query);
-    }, 500);
+    }, 800);
 
     return () => clearTimeout(timer);
   }, [query]);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1059,6 +1059,314 @@ main.container {
   margin-bottom: 5px;
 }
 
+/* ============ PROFILE  ============ */
+
+.farmProfileHeader {
+  background: var(--gradient);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 48px 7%;
+}
+
+.farmProfileTitle {
+  color: #fff;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.farmProfileSubtitle {
+  color: #c8ffd9;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.farmList {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  padding: 32px 7%;
+}
+
+.farmListEmpty {
+  color: var(--muted);
+  padding: 40px 7%;
+  text-align: center;
+}
+
+.farmCard {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.profileCard {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 32px 7%;
+  padding: 20px;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+  width: calc(100% - 14%);
+}
+
+.farmCard:hover {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.farmCardHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.farmCardId {
+  color: var(--primary);
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.farmCardArea {
+  background: var(--brand-50);
+  border-radius: 20px;
+  color: var(--brand-800);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 4px 12px;
+}
+
+.farmCardGrid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.farmCardStat {
+  background: var(--surface);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+}
+
+.farmCardStatLabel {
+  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.farmCardStatValue {
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.farmCardCoords {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.farmCardTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.farmTag {
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 4px 10px;
+}
+
+.farmTagAgroforestry {
+  background: var(--brand-100);
+  color: var(--brand-900);
+}
+
+.farmTagTrait {
+  background: #e8f5e9;
+  border: 1px solid var(--brand-200);
+  color: var(--brand-800);
+}
+
+/* ============ PROFILE PAGE NAVIGATION ============ */
+
+.farmBottomRow {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 7% 40px;
+}
+
+.farmPageNav {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: left;
+  padding: 0;
+}
+
+.farmPageNavBtn {
+  background: var(--gradient);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 24px;
+  transition:
+    background 0.2s ease,
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.farmPageNavBtn:hover:not(:disabled) {
+  background: var(--gradient-dark);
+  box-shadow: 0 8px 20px rgba(14, 122, 67, 0.18);
+  transform: translateY(-1px);
+}
+
+.farmPageNavBtn:disabled {
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.4;
+  transform: none;
+}
+
+.farmPageNavInfo {
+  color: var(--muted);
+  font-size: 0.9rem;
+  min-width: 80px;
+  text-align: center;
+}
+
+/* ============ PROFILE EDIT ACTIONS ============ */
+
+.farmActions {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  padding: 0;
+}
+
+.farmActionBtn {
+  align-items: center;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--primary);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.88rem;
+  font-weight: 600;
+  gap: 6px;
+  padding: 8px 16px;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
+}
+
+.farmActionBtn:hover {
+  background: var(--brand-50);
+  border-color: var(--brand-300);
+  box-shadow: 0 4px 12px rgba(14, 122, 67, 0.1);
+  transform: translateY(-1px);
+}
+
+.farmActionBtnDanger {
+  color: #c0392b;
+}
+
+.farmActionBtnDanger:hover {
+  background: #fdecea;
+  border-color: #f5c2c0;
+  box-shadow: 0 4px 12px rgba(192, 59, 44, 0.1);
+}
+
+/* ============ PROFILE SEARCH ============ */
+
+.profile-search {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-start;
+  padding: 20px 7% 0;
+}
+
+.profile-search .search-input {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  flex: 0 0 280px;
+  font-size: 14px;
+  padding: 12px 14px;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.profile-search .search-input:focus {
+  border-color: var(--brand-500);
+  box-shadow: 0 0 0 3px rgba(31, 212, 111, 0.15);
+  outline: none;
+}
+
+.profile-search .search-btn {
+  background: var(--gradient);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 22px;
+  transition:
+    background 0.2s ease,
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.profile-search .search-btn:hover:not(:disabled) {
+  background: var(--gradient-dark);
+  box-shadow: 0 8px 20px rgba(14, 122, 67, 0.18);
+  transform: translateY(-1px);
+}
+
+.profile-search .search-btn:disabled {
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.4;
+  transform: none;
+}
+
+/* loading text */
+.profile-search span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 /* ============ ERROR BOUNDARY ============ */
 
 .global-error-boundary-text {

--- a/frontend/src/test/__snapshots__/profilePage.snapshot.test.tsx.snap
+++ b/frontend/src/test/__snapshots__/profilePage.snapshot.test.tsx.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProfilePage Snapshot > matches snapshot 1`] = `
+<div>
+  <div>
+    <header
+      class="farmProfileHeader"
+    >
+      <h1
+        class="farmProfileTitle"
+      >
+        Environmental Profile
+      </h1>
+      <p
+        class="farmProfileSubtitle"
+      >
+        John · 0 Farms
+      </p>
+    </header>
+    <div
+      class="profile-search"
+    >
+      <input
+        class="search-input"
+        placeholder="Search by farm ID..."
+        value=""
+      />
+    </div>
+    <p
+      class="farmListEmpty"
+    >
+      No farms found.
+    </p>
+    <div
+      class="farmBottomRow"
+    >
+      <div
+        class="farmActions"
+      >
+        <button
+          class="farmActionBtn farmActionBtnDanger"
+        >
+          🗑️ Delete
+        </button>
+        <button
+          class="farmActionBtn"
+        >
+          ✏️ Edit
+        </button>
+        <button
+          class="farmActionBtn"
+        >
+          ➕ Add
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/test/profileComponents.test.tsx
+++ b/frontend/src/test/profileComponents.test.tsx
@@ -58,25 +58,25 @@ beforeEach(() => {
 // ProfileHeader Tests
 describe("ProfileHeader", () => {
   it("renders the page title", () => {
-    render(<ProfileHeader farmerName="John" farmCount={3} />);
+    render(<ProfileHeader userName="John" farmCount={3} />);
     // The main heading should always be visible regardless of auth state
     expect(screen.getByText("Environmental Profile")).toBeInTheDocument();
   });
 
   it("renders farmer name and farm count when user is logged in", () => {
-    render(<ProfileHeader farmerName="John" farmCount={3} />);
+    render(<ProfileHeader userName="John" farmCount={3} />);
     // Subtitle should show the farmer's name and plural "Farms" when count > 1
     expect(screen.getByText(/John · 3 Farms/i)).toBeInTheDocument();
   });
 
   it("renders singular Farm label when count is 1", () => {
-    render(<ProfileHeader farmerName="John" farmCount={1} />);
+    render(<ProfileHeader userName="John" farmCount={1} />);
     // Verify the singular form is used for exactly one farm
     expect(screen.getByText(/John · 1 Farm/i)).toBeInTheDocument();
   });
 
   it("renders empty subtitle when no farmer name is provided", () => {
-    render(<ProfileHeader farmerName="" farmCount={0} />);
+    render(<ProfileHeader userName="" farmCount={0} />);
     // No separator dot should appear when there is no farmer info to display
     expect(screen.queryByText(/·/)).not.toBeInTheDocument();
   });

--- a/frontend/src/test/profileComponents.test.tsx
+++ b/frontend/src/test/profileComponents.test.tsx
@@ -1,0 +1,543 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Farm } from "@/hooks/useUserProfiles";
+import { EnvironmentalProfile } from "@/hooks/useSearchProfiles";
+import ProfileHeader from "@/components/profile/profileHeader";
+import FarmList from "@/components/profile/profileFarms";
+import FarmCard from "@/components/profile/profileAllCards";
+import FarmPageNav from "@/components/profile/profilePageNav";
+import ProfileEditActions from "@/components/profile/profileEditButtons";
+import FarmSearchInput from "@/components/profile/profileSearchInput";
+import EnvironmentalProfileCard from "@/components/profile/profileSearchedCard";
+import FarmSearchPanel from "@/components/profile/profileSearchPanel";
+
+// Mock Data for farms in useUserProfiles
+const mockFarm = (id: number): Farm => ({
+  id,
+  rainfall_mm: 800,
+  temperature_celsius: 22,
+  elevation_m: 150,
+  ph: 6.5,
+  soil_texture: { name: "Loam" },
+  area_ha: 12.345,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  coastal: true,
+  riparian: false,
+  nitrogen_fixing: true,
+  shade_tolerant: false,
+  bank_stabilising: false,
+  slope: 3.75,
+  agroforestry_type: [{ name: "Silvopasture" }],
+});
+
+// Mock data for EnvironmentalProfile used in search result tests
+const mockProfile = (id: number): EnvironmentalProfile => ({
+  id,
+  elevation_m: 149,
+  ph: 6.5,
+  slope: 4.2,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  area_ha: 0.402,
+  coastal: true,
+});
+
+// Mock Functions
+const mockUseAuth = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+beforeEach(() => {
+  // Reset to a logged-in admin before each test so most components render fully
+  mockUseAuth.mockReturnValue({ user: { name: "Test User", role: "admin" } });
+});
+
+// ProfileHeader Tests
+describe("ProfileHeader", () => {
+  it("renders the page title", () => {
+    render(<ProfileHeader farmerName="John" farmCount={3} />);
+    // The main heading should always be visible regardless of auth state
+    expect(screen.getByText("Environmental Profile")).toBeInTheDocument();
+  });
+
+  it("renders farmer name and farm count when user is logged in", () => {
+    render(<ProfileHeader farmerName="John" farmCount={3} />);
+    // Subtitle should show the farmer's name and plural "Farms" when count > 1
+    expect(screen.getByText(/John · 3 Farms/i)).toBeInTheDocument();
+  });
+
+  it("renders singular Farm label when count is 1", () => {
+    render(<ProfileHeader farmerName="John" farmCount={1} />);
+    // Verify the singular form is used for exactly one farm
+    expect(screen.getByText(/John · 1 Farm/i)).toBeInTheDocument();
+  });
+
+  it("renders empty subtitle when no farmer name is provided", () => {
+    render(<ProfileHeader farmerName="" farmCount={0} />);
+    // No separator dot should appear when there is no farmer info to display
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+  });
+});
+
+// FarmCard Tests
+describe("FarmCard", () => {
+  it("renders farm id and area", () => {
+    render(<FarmCard farm={mockFarm(42)} />);
+    // Verify the farm identifier and area display with correct formatting
+    expect(screen.getByText("Farm #42")).toBeInTheDocument();
+    expect(screen.getByText("12.345 ha")).toBeInTheDocument();
+  });
+
+  it("renders all environmental stats with correct units", () => {
+    render(<FarmCard farm={mockFarm(1)} />);
+    // Verify every core environmental metric appears with the right unit suffix
+    expect(screen.getByText("800 mm")).toBeInTheDocument();
+    expect(screen.getByText("22°C")).toBeInTheDocument();
+    expect(screen.getByText("150 m")).toBeInTheDocument();
+    expect(screen.getByText("6.5")).toBeInTheDocument();
+    expect(screen.getByText("3.75°")).toBeInTheDocument();
+    expect(screen.getByText("Loam")).toBeInTheDocument();
+  });
+
+  it("renders coordinates formatted to 5 decimal places", () => {
+    render(<FarmCard farm={mockFarm(1)} />);
+    // Latitude and longitude should be displayed with their full precision
+    expect(screen.getByText(/-37.12345/)).toBeInTheDocument();
+    expect(screen.getByText(/144.12345/)).toBeInTheDocument();
+  });
+
+  it("renders trait tags only for true boolean flags", () => {
+    render(<FarmCard farm={mockFarm(1)} />);
+    // Only truthy flags (coastal, nitrogen_fixing) should produce visible tags
+    expect(screen.getByText("Coastal")).toBeInTheDocument();
+    expect(screen.getByText("Nitrogen Fixing")).toBeInTheDocument();
+    // False flags (riparian, shade_tolerant, bank_stabilising) must not render
+    expect(screen.queryByText("Riparian")).not.toBeInTheDocument();
+    expect(screen.queryByText("Shade Tolerant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bank Stabilising")).not.toBeInTheDocument();
+  });
+
+  it("renders agroforestry type tags", () => {
+    render(<FarmCard farm={mockFarm(1)} />);
+    // Agroforestry classification tags should appear from the nested array
+    expect(screen.getByText("Silvopasture")).toBeInTheDocument();
+  });
+
+  it("renders N/A for zero ph and slope values", () => {
+    const farm = { ...mockFarm(1), ph: 0, slope: 0 };
+    render(<FarmCard farm={farm} />);
+    // Zero is treated as missing — a fallback "N/A" should be shown
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+    // Slope fallback retains the degree symbol suffix
+    expect(screen.getByText("N/A°")).toBeInTheDocument();
+  });
+
+  it("renders multiple agroforestry type tags when present", () => {
+    const farm = {
+      ...mockFarm(1),
+      agroforestry_type: [{ name: "Silvopasture" }, { name: "Alley Cropping" }],
+    };
+    render(<FarmCard farm={farm} />);
+    // Both agroforestry types should be rendered as separate tags
+    expect(screen.getByText("Silvopasture")).toBeInTheDocument();
+    expect(screen.getByText("Alley Cropping")).toBeInTheDocument();
+  });
+});
+
+// FarmList Tests
+describe("FarmList", () => {
+  const setPage = vi.fn();
+
+  it("shows loading indicator while farms are being fetched", () => {
+    render(
+      <FarmList
+        farms={[]}
+        isLoading={true}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={1}
+        setPage={setPage}
+      />
+    );
+    // A loading message should be shown while data is in flight
+    expect(screen.getByText(/loading farms/i)).toBeInTheDocument();
+  });
+
+  it("shows login prompt when user is null", () => {
+    render(
+      <FarmList
+        farms={[]}
+        isLoading={false}
+        user={null}
+        page={0}
+        totalPages={1}
+        setPage={setPage}
+      />
+    );
+    // Unauthenticated users should be told they need to log in
+    expect(screen.getByText(/logged in/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state message when user is logged in but has no farms", () => {
+    render(
+      <FarmList
+        farms={[]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={1}
+        setPage={setPage}
+      />
+    );
+    // A clear "no farms" message should render when the farm array is empty
+    expect(screen.getByText(/no farms found/i)).toBeInTheDocument();
+  });
+
+  it("renders a card for each farm in the data array", () => {
+    render(
+      <FarmList
+        farms={[mockFarm(1), mockFarm(2)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={1}
+        setPage={setPage}
+      />
+    );
+    // Each farm passed in should produce a visible FarmCard
+    expect(screen.getByText("Farm #1")).toBeInTheDocument();
+    expect(screen.getByText("Farm #2")).toBeInTheDocument();
+  });
+
+  it("disables the Previous button on the first page", () => {
+    render(
+      <FarmList
+        farms={[mockFarm(1)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={3}
+        setPage={setPage}
+      />
+    );
+    // The Previous button must be disabled when there are no earlier pages
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+  });
+
+  it("disables the Next button on the last page", () => {
+    render(
+      <FarmList
+        farms={[mockFarm(1)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={2}
+        totalPages={3}
+        setPage={setPage}
+      />
+    );
+    // The Next button must be disabled when already on the final page
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+  });
+
+  it("displays the correct current page number in the pagination info", () => {
+    render(
+      <FarmList
+        farms={[mockFarm(1)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={1}
+        totalPages={3}
+        setPage={setPage}
+      />
+    );
+    // Page index is zero-based internally but displayed as 1-based to the user
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+  });
+
+  it("shows edit actions alongside the empty state for logged-in users", () => {
+    render(
+      <FarmList
+        farms={[]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={0}
+        setPage={setPage}
+      />
+    );
+    // Even with no farms, the action buttons should render for authenticated users
+    expect(screen.getByText(/no farms found/i)).toBeInTheDocument();
+    // Admin role (set in beforeEach) means all three action buttons appear
+    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+  });
+});
+
+// FarmPageNav Tests
+describe("FarmPageNav", () => {
+  it("renders Previous, page info, and Next controls", () => {
+    const setPage = vi.fn();
+    render(<FarmPageNav page={1} totalPages={3} setPage={setPage} />);
+    // All three navigation elements should be present at once
+    expect(
+      screen.getByRole("button", { name: /previous/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+  });
+
+  it("disables Previous on page 0", () => {
+    const setPage = vi.fn();
+    render(<FarmPageNav page={0} totalPages={3} setPage={setPage} />);
+    // The Previous button must be disabled when there are no earlier pages
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+  });
+
+  it("disables Next on the last page", () => {
+    const setPage = vi.fn();
+    render(<FarmPageNav page={2} totalPages={3} setPage={setPage} />);
+    // The Next button must be disabled when already on the final page
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+  });
+
+  it("enables both buttons when on a middle page", () => {
+    const setPage = vi.fn();
+    render(<FarmPageNav page={1} totalPages={3} setPage={setPage} />);
+    // Neither button should be disabled when there are pages in both directions
+    expect(
+      screen.getByRole("button", { name: /previous/i })
+    ).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled();
+  });
+});
+
+// ProfileEditActions Tests
+describe("ProfileEditActions", () => {
+  it("renders Add button for regular logged-in users", () => {
+    // A basic authenticated user (no elevated role) should only see Add
+    mockUseAuth.mockReturnValue({ user: { name: "User", role: "user" } });
+    render(<ProfileEditActions />);
+    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Edit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Delete/i)).not.toBeInTheDocument();
+  });
+
+  it("renders Add and Edit buttons for supervisors", () => {
+    // Supervisors have elevated write access but cannot delete
+    mockUseAuth.mockReturnValue({
+      user: { name: "Supervisor", role: "supervisor" },
+    });
+    render(<ProfileEditActions />);
+    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+    expect(screen.getByText(/Edit/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Delete/i)).not.toBeInTheDocument();
+  });
+
+  it("renders Add, Edit, and Delete buttons for admins", () => {
+    // Admins have full CRUD access — all three action buttons should appear
+    mockUseAuth.mockReturnValue({ user: { name: "Admin", role: "admin" } });
+    render(<ProfileEditActions />);
+    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+    expect(screen.getByText(/Edit/i)).toBeInTheDocument();
+    expect(screen.getByText(/Delete/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when user is not logged in", () => {
+    // Unauthenticated users should see no action controls at all
+    mockUseAuth.mockReturnValue({ user: null });
+    const { container } = render(<ProfileEditActions />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// FarmSearchInput Tests
+describe("FarmSearchInput", () => {
+  it("renders the search input with placeholder text", () => {
+    render(
+      <FarmSearchInput
+        value=""
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        isLoading={false}
+      />
+    );
+    // The input should always be present with its descriptive placeholder
+    expect(
+      screen.getByPlaceholderText(/search by farm id/i)
+    ).toBeInTheDocument();
+  });
+
+  it("reflects the current value in the input field", () => {
+    render(
+      <FarmSearchInput
+        value="42"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        isLoading={false}
+      />
+    );
+    // The controlled input should display whatever value is passed as a prop
+    expect(screen.getByDisplayValue("42")).toBeInTheDocument();
+  });
+
+  it("shows a Clear button only when a value is present", () => {
+    render(
+      <FarmSearchInput
+        value="42"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        isLoading={false}
+      />
+    );
+    // The Clear button should only appear when there is text to clear
+    expect(screen.getByText("Clear")).toBeInTheDocument();
+  });
+
+  it("hides the Clear button when value is empty", () => {
+    render(
+      <FarmSearchInput
+        value=""
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        isLoading={false}
+      />
+    );
+    // With no query text the Clear button should not be rendered
+    expect(screen.queryByText("Clear")).not.toBeInTheDocument();
+  });
+
+  it("disables the input while isLoading is true", () => {
+    render(
+      <FarmSearchInput
+        value=""
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        isLoading={true}
+      />
+    );
+    // The input should be non-interactive while a search is in progress
+    expect(screen.getByPlaceholderText(/search by farm id/i)).toBeDisabled();
+  });
+});
+
+// EnvironmentalProfileCard Tests
+describe("EnvironmentalProfileCard", () => {
+  it("renders the farm ID in the card header", () => {
+    render(<EnvironmentalProfileCard profile={mockProfile(42)} />);
+    // The profile ID should appear as the primary identifier in the card header
+    expect(screen.getByText("Farm #42")).toBeInTheDocument();
+  });
+
+  it("renders area when provided", () => {
+    render(<EnvironmentalProfileCard profile={mockProfile(1)} />);
+    // Area should be formatted to 3 decimal places when the value is non-null
+    expect(screen.getByText("0.402 ha")).toBeInTheDocument();
+  });
+
+  it("renders elevation, ph, and slope stats", () => {
+    render(<EnvironmentalProfileCard profile={mockProfile(1)} />);
+    // The three environmental stats should all be visible with correct values
+    expect(screen.getByText(/149/)).toBeInTheDocument();
+    expect(screen.getByText("6.5")).toBeInTheDocument();
+    expect(screen.getByText(/4.20/)).toBeInTheDocument();
+  });
+
+  it("renders coordinates to 5 decimal places", () => {
+    render(<EnvironmentalProfileCard profile={mockProfile(1)} />);
+    // Coordinates must be shown with their full precision
+    expect(screen.getByText(/-37.12345/)).toBeInTheDocument();
+    expect(screen.getByText(/144.12345/)).toBeInTheDocument();
+  });
+
+  it("renders the Coastal trait tag when coastal is true", () => {
+    render(<EnvironmentalProfileCard profile={mockProfile(1)} />);
+    // A Coastal tag should appear when the coastal flag is set to true
+    expect(screen.getByText("Coastal")).toBeInTheDocument();
+  });
+
+  it("does not render the Coastal tag when coastal is false", () => {
+    const profile = { ...mockProfile(1), coastal: false };
+    render(<EnvironmentalProfileCard profile={profile} />);
+    // When coastal is false no tag should be rendered
+    expect(screen.queryByText("Coastal")).not.toBeInTheDocument();
+  });
+
+  it("shows N/A for missing ph value", () => {
+    const profile = { ...mockProfile(1), ph: undefined };
+    render(<EnvironmentalProfileCard profile={profile} />);
+    // Missing optional fields should fall back to a visible N/A placeholder
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+});
+
+// FarmSearchPanel Tests
+describe("FarmSearchPanel", () => {
+  const baseProps = {
+    query: "",
+    setQuery: vi.fn(),
+    profile: null,
+    isLoading: false,
+    error: null,
+    user: { name: "John" },
+  };
+
+  it("renders the search input", () => {
+    render(<FarmSearchPanel {...baseProps} />);
+    // The search input should always be present regardless of query or auth state
+    expect(
+      screen.getByPlaceholderText(/search by farm id/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message when error prop is set", () => {
+    render(<FarmSearchPanel {...baseProps} error="Profile not found" />);
+    // API or network errors should be surfaced to the user as a visible message
+    expect(screen.getByText("Profile not found")).toBeInTheDocument();
+  });
+
+  it("shows loading indicator while a search is in progress", () => {
+    render(<FarmSearchPanel {...baseProps} query="42" isLoading={true} />);
+    // A loading message should appear whenever a query is active and loading
+    expect(screen.getByText(/loading profile/i)).toBeInTheDocument();
+  });
+
+  it("renders the profile card when a result is returned", () => {
+    render(
+      <FarmSearchPanel {...baseProps} query="42" profile={mockProfile(42)} />
+    );
+    // A successful search result should display the profile card with the farm ID
+    expect(screen.getByText("Farm #42")).toBeInTheDocument();
+  });
+
+  it("shows 'no profile found' when query is active but no result and user is logged in", () => {
+    render(
+      <FarmSearchPanel {...baseProps} query="999" profile={null} error={null} />
+    );
+    // When a query returns nothing (and there's no error) show a friendly empty state
+    expect(screen.getByText(/no profile found/i)).toBeInTheDocument();
+  });
+
+  it("shows login required message when query is active but user is null", () => {
+    render(
+      <FarmSearchPanel
+        {...baseProps}
+        query="42"
+        user={null}
+        profile={null}
+        error={null}
+      />
+    );
+    // Unauthenticated users trying to search should be prompted to log in
+    expect(screen.getByText(/must be logged in/i)).toBeInTheDocument();
+  });
+
+  it("does not show any search result state when query is empty", () => {
+    render(<FarmSearchPanel {...baseProps} query="" />);
+    // With no active query none of the result/empty/loading states should appear
+    expect(screen.queryByText(/loading profile/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/no profile found/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/must be logged in/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/profileComponents.test.tsx
+++ b/frontend/src/test/profileComponents.test.tsx
@@ -315,22 +315,22 @@ describe("FarmPageNav", () => {
 
 // ProfileEditActions Tests
 describe("ProfileEditActions", () => {
-  it("renders Add button for regular logged-in users", () => {
+  it("renders no buttons for regular logged-in users", () => {
     // A basic authenticated user (no elevated role) should only see Add
-    mockUseAuth.mockReturnValue({ user: { name: "User", role: "user" } });
+    mockUseAuth.mockReturnValue({ user: { name: "User", role: "officer" } });
     render(<ProfileEditActions />);
-    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Add/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Edit/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Delete/i)).not.toBeInTheDocument();
   });
 
-  it("renders Add and Edit buttons for supervisors", () => {
+  it("renders Edit button for supervisors", () => {
     // Supervisors have elevated write access but cannot delete
     mockUseAuth.mockReturnValue({
       user: { name: "Supervisor", role: "supervisor" },
     });
     render(<ProfileEditActions />);
-    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Add/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Edit/i)).toBeInTheDocument();
     expect(screen.queryByText(/Delete/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/test/profilePage.interaction.test.tsx
+++ b/frontend/src/test/profilePage.interaction.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Farm } from "@/hooks/useUserProfiles";
+import { EnvironmentalProfile } from "@/hooks/useSearchProfiles";
+import FarmList from "@/components/profile/profileFarms";
+import FarmPageNav from "@/components/profile/profilePageNav";
+import FarmSearchInput from "@/components/profile/profileSearchInput";
+import FarmSearchPanel from "@/components/profile/profileSearchPanel";
+
+// Mock Data for farms in useUserProfiles
+const mockFarm = (id: number): Farm => ({
+  id,
+  rainfall_mm: 800,
+  temperature_celsius: 22,
+  elevation_m: 150,
+  ph: 6.5,
+  soil_texture: { name: "Loam" },
+  area_ha: 12.345,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  coastal: true,
+  riparian: false,
+  nitrogen_fixing: true,
+  shade_tolerant: false,
+  bank_stabilising: false,
+  slope: 3.75,
+  agroforestry_type: [{ name: "Silvopasture" }],
+});
+
+// Mock data for EnvironmentalProfile used in search result tests
+const mockProfile = (id: number): EnvironmentalProfile => ({
+  id,
+  elevation_m: 149,
+  ph: 6.5,
+  slope: 4.2,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  area_ha: 0.402,
+  coastal: true,
+});
+
+// Mock Functions
+const mockUseAuth = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+beforeEach(() => {
+  // Reset to a logged-in admin before each test so all action buttons are available
+  mockUseAuth.mockReturnValue({ user: { name: "Test User", role: "admin" } });
+});
+
+// FarmList Interaction Tests
+describe("FarmList interactions", () => {
+  it("calls setPage when the Next button is clicked", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(
+      <FarmList
+        farms={[mockFarm(1)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={0}
+        totalPages={3}
+        setPage={setPage}
+      />
+    );
+    // Clicking Next should invoke the page-change callback
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(setPage).toHaveBeenCalled();
+  });
+
+  it("calls setPage when the Previous button is clicked on a non-first page", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(
+      <FarmList
+        farms={[mockFarm(1)]}
+        isLoading={false}
+        user={{ name: "John" }}
+        page={1}
+        totalPages={3}
+        setPage={setPage}
+      />
+    );
+    // Clicking Previous should invoke the page-change callback
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    expect(setPage).toHaveBeenCalled();
+  });
+});
+
+// FarmPageNav Interaction Tests
+describe("FarmPageNav interactions", () => {
+  it("calls setPage with page - 1 when Previous is clicked", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(<FarmPageNav page={2} totalPages={3} setPage={setPage} />);
+    // Clicking Previous should decrement the page by one
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    expect(setPage).toHaveBeenCalledWith(1);
+  });
+
+  it("calls setPage with page + 1 when Next is clicked", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(<FarmPageNav page={0} totalPages={3} setPage={setPage} />);
+    // Clicking Next should increment the page index by one
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(setPage).toHaveBeenCalledWith(1);
+  });
+
+  it("does not call setPage when Previous is clicked while disabled", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(<FarmPageNav page={0} totalPages={3} setPage={setPage} />);
+    // A disabled Previous button should not trigger the callback
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    expect(setPage).not.toHaveBeenCalled();
+  });
+
+  it("does not call setPage when Next is clicked while disabled", async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(<FarmPageNav page={2} totalPages={3} setPage={setPage} />);
+    // A disabled Next button should not trigger the callback
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(setPage).not.toHaveBeenCalled();
+  });
+});
+
+// FarmSearchInput Interaction Tests
+describe("FarmSearchInput interactions", () => {
+  it("calls onChange when the user types in the input", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FarmSearchInput
+        value=""
+        onChange={onChange}
+        onClear={vi.fn()}
+        isLoading={false}
+      />
+    );
+    // Typing a character should fire the onChange handler with the new value
+    await user.type(screen.getByPlaceholderText(/search by farm id/i), "5");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("calls onClear when the Clear button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+    render(
+      <FarmSearchInput
+        value="42"
+        onChange={vi.fn()}
+        onClear={onClear}
+        isLoading={false}
+      />
+    );
+    // Clicking Clear should invoke the clear callback to reset the query
+    await user.click(screen.getByText("Clear"));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onChange when input is disabled during loading", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FarmSearchInput
+        value=""
+        onChange={onChange}
+        onClear={vi.fn()}
+        isLoading={true}
+      />
+    );
+    // A disabled input should not fire onChange even if the user attempts to type
+    await user.type(screen.getByPlaceholderText(/search by farm id/i), "5");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// FarmSearchPanel Interaction Tests
+describe("FarmSearchPanel interactions", () => {
+  const baseProps = {
+    query: "",
+    setQuery: vi.fn(),
+    profile: null,
+    isLoading: false,
+    error: null,
+    user: { name: "John" },
+  };
+
+  it("shows edit actions alongside a returned profile", async () => {
+    // Admin role (set in beforeEach) means all action buttons should appear with a result
+    render(
+      <FarmSearchPanel {...baseProps} query="42" profile={mockProfile(42)} />
+    );
+    // Both the profile card and the Add action button should be visible together
+    expect(screen.getByText("Farm #42")).toBeInTheDocument();
+    expect(screen.getByText(/Add/i)).toBeInTheDocument();
+  });
+
+  it("calls setQuery when the user types in the search input", async () => {
+    const user = userEvent.setup();
+    const setQuery = vi.fn();
+    render(<FarmSearchPanel {...baseProps} setQuery={setQuery} />);
+    // Typing in the search input should propagate the new value via setQuery
+    await user.type(screen.getByPlaceholderText(/search by farm id/i), "5");
+    expect(setQuery).toHaveBeenCalled();
+  });
+
+  it("calls setQuery with empty string when Clear is clicked", async () => {
+    const user = userEvent.setup();
+    const setQuery = vi.fn();
+    render(<FarmSearchPanel {...baseProps} query="42" setQuery={setQuery} />);
+    // Clicking Clear should reset the query to an empty string
+    await user.click(screen.getByText("Clear"));
+    expect(setQuery).toHaveBeenCalledWith("");
+  });
+});

--- a/frontend/src/test/profilePage.snapshot.test.tsx
+++ b/frontend/src/test/profilePage.snapshot.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Page to test
+import ProfilePage from "../pages/ProfilePage";
+
+// Mock Functions
+vi.mock("../hooks/useUserProfiles", () => ({
+  useUserProfiles: () => ({
+    farms: [],
+    isLoading: false,
+    error: null,
+    page: 0,
+    setPage: vi.fn(),
+    totalPages: 0,
+    totalFarms: 0,
+  }),
+}));
+
+vi.mock("../hooks/useSearchProfiles", () => ({
+  useSearchProfiles: () => ({
+    profile: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Mock authentication context with a logged-in user
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { name: "John", role: "admin" },
+    getAccessToken: () => "fake-token",
+  }),
+}));
+
+// ProfilePage Snapshot Tests
+describe("ProfilePage Snapshot", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ProfilePage />
+      </MemoryRouter>
+    );
+    // Snapshot captures the full rendered output
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/test/profilePage.test.tsx
+++ b/frontend/src/test/profilePage.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+
+// Page to test
+import ProfilePage from "../pages/ProfilePage";
+
+// Mock Functions
+vi.mock("../hooks/useUserProfiles", () => ({
+  useUserProfiles: () => ({
+    farms: [],
+    isLoading: false,
+    error: null,
+    page: 0,
+    setPage: vi.fn(),
+    totalPages: 0,
+    totalFarms: 0,
+  }),
+}));
+
+vi.mock("../hooks/useSearchProfiles", () => ({
+  useSearchProfiles: () => ({
+    profile: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Mock authentication with a logged-in user
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { name: "John", role: "admin" },
+    getAccessToken: () => "fake-token",
+  }),
+}));
+
+// ProfilePage Tests
+describe("ProfilePage", () => {
+  it("renders the page title", () => {
+    render(
+      <BrowserRouter>
+        <ProfilePage />
+      </BrowserRouter>
+    );
+    // The main Environmental Profile heading should always be present on the page
+    expect(screen.getByText("Environmental Profile")).toBeInTheDocument();
+  });
+
+  it("renders the farmer name in the header", () => {
+    render(
+      <BrowserRouter>
+        <ProfilePage />
+      </BrowserRouter>
+    );
+    // The header subtitle should show the authenticated user's name
+    expect(screen.getByText(/John/i)).toBeInTheDocument();
+  });
+
+  it("renders the search input", () => {
+    render(
+      <BrowserRouter>
+        <ProfilePage />
+      </BrowserRouter>
+    );
+    // The search panel's input should always be visible on the profile page
+    expect(
+      screen.getByPlaceholderText(/search by farm id/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty farms state when user has no farms", () => {
+    render(
+      <BrowserRouter>
+        <ProfilePage />
+      </BrowserRouter>
+    );
+    // With no farms returned from the hook the empty state message should appear
+    expect(screen.getByText(/no farms found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/useSearchProfiles.test.ts
+++ b/frontend/src/test/useSearchProfiles.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSearchProfiles } from "@/hooks/useSearchProfiles";
+
+// Mock Data
+const mockProfile = (id: number) => ({
+  id,
+  elevation_m: 149,
+  ph: 6.5,
+  slope: 4.2,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  area_ha: 0.402,
+  coastal: true,
+});
+
+// Mock Functions
+const mockGetAccessToken = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+// useSearchProfiles Tests
+describe("useSearchProfiles Hook", () => {
+  // Before each test clear all mock functions, set mock get access token to fake,
+  // and map global.fetch to a mock function
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue("fake-token");
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  it("fetches and returns a profile successfully when given a valid query", async () => {
+    // Create a mock profile to return from the API
+    const mockData = mockProfile(42);
+    // Configure fetch to return a successful response with the mock profile
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    // Render the hook with a valid query string matching the profile ID
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    // Wait for loading to complete before asserting
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect fetch to have been called with the correct profile endpoint and auth header
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/profile/42"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fake-token",
+        }),
+      })
+    );
+
+    // Expect the returned profile to match the mock data
+    expect(result.current.profile).toMatchObject({ id: 42, elevation_m: 149 });
+    expect(result.current.error).toBe(null);
+  });
+
+  it("does not fetch if query is empty string", async () => {
+    // Render with an empty query useSearchProfiles the hook should skip the fetch entirely
+    const { result } = renderHook(() => useSearchProfiles(""));
+
+    // Expect no call to have been made and profile to remain null
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.profile).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("does not fetch if query is only whitespace", async () => {
+    // Queries with only spaces should be treated the same as empty useSearchProfiles no fetch
+    const { result } = renderHook(() => useSearchProfiles("   "));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.profile).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("does not fetch if token is null", async () => {
+    // Without an auth token the hook should stop before making any request
+    mockGetAccessToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    // Expect no fetch call and a clean state
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.profile).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("refetches when query changes", async () => {
+    // Stub fetch to return an empty successful response for both calls
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockProfile(1),
+    } as Response);
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Start with query "1" and capture the rerender function
+    let query = "1";
+    const { rerender } = renderHook(() => useSearchProfiles(query));
+
+    // Wait for the first fetch triggered by query "1"
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Change the query to "2" and re-render the hook
+    query = "2";
+    rerender();
+
+    // The hook should detect the query change and fire a second fetch
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("refetches when token changes", async () => {
+    // Stub fetch to always return a successful empty-profile response
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockProfile(5),
+    } as Response);
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    let token = "token-1";
+    mockGetAccessToken.mockImplementation(() => token);
+
+    // Render with an initial token
+    const { rerender } = renderHook(() => useSearchProfiles("5"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Swap to a new token and trigger a re-render
+    token = "token-2";
+    rerender();
+
+    // The hook should respond to the token change and fetch again
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("handles API errors with a detail string and sets error state", async () => {
+    // Return a 404 response containing a detail message
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: "Profile not found" }),
+    } as Response);
+
+    const { result } = renderHook(() => useSearchProfiles("99"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect the hook to show the detail message as the error
+    expect(result.current.error).toBe("Profile not found");
+    expect(result.current.profile).toBe(null);
+  });
+
+  it("handles non-Error objects thrown during fetch", async () => {
+    // Mock fetch rejecting with a plain string rather than an Error instance
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      "Unexpected string error"
+    );
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect the fallback error message for non-Error thrown values
+    expect(result.current.error).toBe("Unexpected error");
+    expect(result.current.profile).toBe(null);
+  });
+
+  it("clears profile and error when query is cleared after a successful fetch", async () => {
+    // First, return a successful profile
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockProfile(1),
+    } as Response);
+
+    let query = "1";
+    const { result, rerender } = renderHook(() => useSearchProfiles(query));
+
+    await waitFor(() => {
+      expect(result.current.profile).not.toBe(null);
+    });
+
+    // Now clear the query useSearchProfiles the hook should reset
+    query = "";
+    rerender();
+
+    expect(result.current.profile).toBe(null);
+    expect(result.current.error).toBe(null);
+  });
+});

--- a/frontend/src/test/useUserProfiles.test.ts
+++ b/frontend/src/test/useUserProfiles.test.ts
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useUserProfiles } from "@/hooks/useUserProfiles";
+
+// Mock Data
+const mockFarm = (id: number) => ({
+  id,
+  rainfall_mm: 800,
+  temperature_celsius: 22,
+  elevation_m: 150,
+  ph: 6.5,
+  soil_texture: { name: "Loam" },
+  area_ha: 12.345,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  coastal: true,
+  riparian: false,
+  nitrogen_fixing: true,
+  shade_tolerant: false,
+  bank_stabilising: false,
+  slope: 3.75,
+  agroforestry_type: [{ name: "Silvopasture" }],
+});
+
+// Mock Functions
+const mockGetAccessToken = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+// useUserProfiles Tests
+describe("useUserProfiles Hook", () => {
+  // Before each test clear all mock functions, set mock get access token to fake, and map
+  // global.fetch to a mock function
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue("fake-token");
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  it("fetches and returns farm data successfully", async () => {
+    // Create two mock farms to simulate a real API response
+    const mockData = [mockFarm(1), mockFarm(2)];
+    // Configure fetch to return a successful HTTP response with the mock farm array
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    // Render the hook and capture the result
+    const { result } = renderHook(() => useUserProfiles());
+
+    // Wait for the loading state to clear before asserting on the data
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect fetch to have been called with the correct user items and auth token
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/users/me/items"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fake-token",
+        }),
+      })
+    );
+
+    // Expect the returned data to match the two mock farms created
+    expect(result.current.farms).toHaveLength(2);
+    expect(result.current.totalFarms).toBe(2);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("does not fetch if token is null", async () => {
+    // Without a token the hook should skip the fetch entirely
+    mockGetAccessToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    // Expect no call and a empty page
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.farms).toHaveLength(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("refetches when token changes", async () => {
+    // Stub fetch to return a successful empty array for both fetches
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Start with the first token value
+    let token = "token-1";
+    mockGetAccessToken.mockImplementation(() => token);
+
+    // Render the hook and capture the rerender function
+    const { rerender } = renderHook(() => useUserProfiles());
+
+    // Wait for the first fetch triggered by the initial token
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Update to a new token and re-render
+    token = "token-2";
+    rerender();
+
+    // Confirm the hook responded to the token change with a second fetch
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("handles API errors and sets error state", async () => {
+    // Return a 500 response with a plain-text error
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    } as Response);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    // Wait for loading to finish so we can inspect the error state
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Internal Server Error");
+    expect(result.current.farms).toHaveLength(0);
+  });
+
+  it("handles API errors without error text by using fallback message", async () => {
+    // Return a response with an empty body to trigger the fallback error format
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "",
+    } as Response);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect the fallback message
+    expect(result.current.error).toBe("Failed to fetch farms (404)");
+    expect(result.current.farms).toHaveLength(0);
+  });
+
+  it("navigate pages correctly with PAGE_SIZE of 9", async () => {
+    // Create 20 farms to verify page navigaton splits the data correctly across pages
+    const mockData = Array.from({ length: 20 }, (_, i) => mockFarm(i + 1));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect the first page to show 9 of 20 total farms across 3 pages, starting on page 0
+    expect(result.current.farms).toHaveLength(9);
+    expect(result.current.totalPages).toBe(3);
+    expect(result.current.totalFarms).toBe(20);
+    expect(result.current.page).toBe(0);
+  });
+
+  it("can change pages", async () => {
+    // Create 20 farms so there are enough for a third partial page
+    const mockData = Array.from({ length: 20 }, (_, i) => mockFarm(i + 1));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Navigate to the third page (index 2)
+    act(() => {
+      result.current.setPage(2);
+    });
+
+    // Expect page index to update and show the remaining 2 farms on the last page
+    expect(result.current.page).toBe(2);
+    expect(result.current.farms).toHaveLength(2);
+  });
+
+  it("handles empty farm list", async () => {
+    // Return an empty array
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect all counts to be zero and no error to be set
+    expect(result.current.farms).toHaveLength(0);
+    expect(result.current.totalFarms).toBe(0);
+    expect(result.current.totalPages).toBe(0);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("handles non-Error objects thrown during fetch", async () => {
+    // Reject with a plain string to test the non-Error fallback path
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      "Unexpected string error"
+    );
+
+    const { result } = renderHook(() => useUserProfiles());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Expect the generic fallback message when the thrown value is not an Error instance
+    expect(result.current.error).toBe("An unexpected error occurred");
+    expect(result.current.farms).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description
This PR adds a basic display of an environmental profile from a user. Displaying all their farms and relevant data that is being stored in the backend. I tried to follow how other frontend tasks were completed.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Closes #308  Closes #191  Closes #192  Closes #193  

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [X] Frontend
- [ ] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] My code follows the project’s style guidelines (linting & formatting)
- [X] This PR is based on the latest `upstream/master`
- [X] I have updated documentation if necessary

## Additional Notes
When merging with upstream I basically made some mistakes which was a nightmare to try and fix/revert given how I did my code, so I've just rebuilt it from a clean branch and the only changes should be the ones relating to the profile page. You'll need to login to see all the features, the current edit actions button, e.g. add, edit, delete, are currently placeholders and don't call to anything. You'll need to have the admin role to look up farms not owned by that account. Currently, the way it works is, it displays all of the accounts farms on startup using /auth, and the search bar is the one that uses the /profile which gets the environmental profile from GIS, though the /profile endpoint hands back less data than the /auth. Hopefully it should all be working now.