### PR TITLE
Pre-commit fix, frontend overriding others

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,2 +1,8 @@
+if git diff --cached --name-only | grep -qE '^(backend|datascience|gis)/'; then
+    if command -v pre-commit >/dev/null 2>&1; then
+        pre-commit run
+    fi
+fi
+
 cd frontend
 npx lint-staged

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: web
     name: pot-backend
     runtime: docker
+    plan: free
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
     # Runs migrations before the new instance goes live.
@@ -61,6 +62,7 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
+    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,8 @@
+# NOTE: This file serves as reference documentation only. Blueprint deployment is not
+# currently usable because Docker web services require a paid Render plan, and the
+# shared project account has no payment method on file. Services must be created and
+# managed manually via the Render dashboard. See GitHub issue for details.
+
 services:
   - type: web
     name: pot-backend
@@ -61,7 +66,6 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
-    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,3 @@
-# NOTE: This file serves as reference documentation only. Blueprint deployment is not
-# currently usable because Docker web services require a paid Render plan, and the
-# shared project account has no payment method on file. Services must be created and
-# managed manually via the Render dashboard. See GitHub issue for details.
-
 services:
   - type: web
     name: pot-backend
@@ -66,6 +61,7 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
+    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,6 @@ services:
   - type: web
     name: pot-backend
     runtime: docker
-    plan: free
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
     # Runs migrations before the new instance goes live.

--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,6 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
-    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
husky sets `core.hooksPath = frontend/.husky/_` globally, which silently bypasses the root-level `.pre-commit-config.yaml`. Backend ruff and pytest pre-commit hooks were never running on commit.

Fix: `frontend/.husky/pre-commit` now checks whether any staged files are under `backend/`, `datascience/`, or `gis/` and, if so, invokes `pre-commit run`. It silently skips if `pre-commit` is not installed, keeping the hook optional for team members who choose not to use it.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Not applicable to any task.

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [x] Backend
- [x] Data Science
- [x] GIS
- [ ] Documentation
- [x] Other (please specify): pre-commit users

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
