### PR TITLE
Fix - reduce species image dimensions and align card grid

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -6,3 +6,4 @@ fi
 
 cd frontend
 npx lint-staged
+npm run test

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -6,4 +6,6 @@ fi
 
 cd frontend
 npx lint-staged
+npm run lint:scripts
+npm run lint:styles
 npm run test

--- a/frontend/src/components/species/speciesCard.tsx
+++ b/frontend/src/components/species/speciesCard.tsx
@@ -9,7 +9,7 @@ export default function SpeciesCard({ item, onClick }: SpeciesCardProps) {
   const { name, image } = item.fields;
 
   const imageUrl = image?.fields?.file?.url
-    ? `https:${image.fields.file.url}`
+    ? `https:${image.fields.file.url}?w=700&fm=webp&q=80`
     : "https://placehold.co/600x400?text=No+Image";
 
   return (

--- a/frontend/src/components/species/speciesModal.tsx
+++ b/frontend/src/components/species/speciesModal.tsx
@@ -16,7 +16,7 @@ export default function SpeciesModal({ item, onClose }: SpeciesModalProps) {
 
   // Build imageUrl from fields
   const imageUrl = image?.fields?.file?.url
-    ? `https:${image.fields.file.url}`
+    ? `https:${image.fields.file.url}?w=500&fm=webp&q=85`
     : "";
 
   return (

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -626,10 +626,10 @@ main.container {
 
 .species-grid {
   display: grid;
-  gap: 18px;
+  gap: 1.5rem;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-top: 20px;
-  padding: 10px;
+  padding: 0.5rem 10% 3rem;
 }
 
 .species-empty {
@@ -651,8 +651,7 @@ main.container {
 .article-media {
   aspect-ratio: 4 / 3;
   background: var(--surface);
-  display: grid;
-  place-items: center;
+  overflow: hidden;
   width: 100%;
 }
 

--- a/frontend/src/test/species.test.tsx
+++ b/frontend/src/test/species.test.tsx
@@ -195,7 +195,10 @@ describe("SpeciesModal", () => {
     // Create const img that is from the HTML labelled 'img'
     const img = screen.getByRole("img");
     // Expect img to have link to fake image
-    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg?w=500&fm=webp&q=85");
+    expect(img).toHaveAttribute(
+      "src",
+      "https://image.fakeasset.net/test.jpg?w=500&fm=webp&q=85"
+    );
   });
 
   it("should render rich text description content", () => {
@@ -241,7 +244,10 @@ describe("SpeciesCard", () => {
 
     // Expect image to have the correct src built from the url
     const img = screen.getByRole("img");
-    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg?w=700&fm=webp&q=80");
+    expect(img).toHaveAttribute(
+      "src",
+      "https://image.fakeasset.net/test.jpg?w=700&fm=webp&q=80"
+    );
   });
 
   it("should render a fallback image when no image is provided", () => {

--- a/frontend/src/test/species.test.tsx
+++ b/frontend/src/test/species.test.tsx
@@ -195,7 +195,7 @@ describe("SpeciesModal", () => {
     // Create const img that is from the HTML labelled 'img'
     const img = screen.getByRole("img");
     // Expect img to have link to fake image
-    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg");
+    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg?w=500&fm=webp&q=85");
   });
 
   it("should render rich text description content", () => {
@@ -241,7 +241,7 @@ describe("SpeciesCard", () => {
 
     // Expect image to have the correct src built from the url
     const img = screen.getByRole("img");
-    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg");
+    expect(img).toHaveAttribute("src", "https://image.fakeasset.net/test.jpg?w=700&fm=webp&q=80");
   });
 
   it("should render a fallback image when no image is provided", () => {

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: web
     name: pot-backend
     runtime: docker
+    plan: free
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
     # Runs migrations before the new instance goes live.
@@ -61,6 +62,7 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
+    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,8 @@
+# NOTE: This file serves as reference documentation only. Blueprint deployment is not
+# currently usable because Docker web services require a paid Render plan, and the
+# shared project account has no payment method on file. Services must be created and
+# managed manually via the Render dashboard. See GitHub issue for details.
+
 services:
   - type: web
     name: pot-backend
@@ -61,7 +66,6 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
-    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,3 @@
-# NOTE: This file serves as reference documentation only. Blueprint deployment is not
-# currently usable because Docker web services require a paid Render plan, and the
-# shared project account has no payment method on file. Services must be created and
-# managed manually via the Render dashboard. See GitHub issue for details.
-
 services:
   - type: web
     name: pot-backend
@@ -66,6 +61,7 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
+    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,6 @@ services:
   - type: web
     name: pot-backend
     runtime: docker
-    plan: free
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
     # Runs migrations before the new instance goes live.

--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,6 @@ services:
   - type: web
     name: pot-frontend
     runtime: static
-    plan: free
     buildCommand: npm install && npm run build
     staticPublishPath: ./frontend/build/dist
     rootDir: frontend


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
Species images were loading at full resolution from Contentful, resulting in 150mb per pageload.
I've capped them and now page load is 2.2mb on my 1440P 27" monitor without noticeable degradation in quality.

Aligned the grid and added some padding to the cards to make it look (imo) nicer.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Not related to an existing issue

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [ ] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
