### PR TITLE
Fix/migrate-dem-table

### DIFF
--- a/backend/ERD.md
+++ b/backend/ERD.md
@@ -31,6 +31,11 @@ erDiagram
     INTEGER external_id UK "nullable"
   }
 
+  dem_table {
+    INTEGER rid PK
+    raster rast "nullable"
+  }
+
   farm_agroforestry_association {
     INTEGER agroforestry_type_id PK,FK
     INTEGER farm_id PK,FK
@@ -44,23 +49,21 @@ erDiagram
     BOOLEAN bank_stabilising
     BOOLEAN coastal
     INTEGER elevation_m
+    BOOLEAN elevation_m_imputed
     INTEGER external_id UK "nullable"
     FLOAT latitude
     FLOAT longitude
     BOOLEAN nitrogen_fixing
     FLOAT ph
+    BOOLEAN ph_imputed
     INTEGER rainfall_mm
+    BOOLEAN rainfall_mm_imputed
     BOOLEAN riparian
     BOOLEAN shade_tolerant
     FLOAT slope
+    BOOLEAN slope_imputed
     INTEGER temperature_celsius
-  }
-
-  waterways {
-    INTEGER id PK
-    geometry(GEOMETRY-4326) geometry
-    VARCHAR name "nullable"
-    VARCHAR waterway "nullable"
+    BOOLEAN temperature_celsius_imputed
   }
 
   parameters {

--- a/backend/SCHEMA.md
+++ b/backend/SCHEMA.md
@@ -24,6 +24,12 @@
 | :--- | :--- | :--- | :--- | :--- |
 | `id` | `Integer` | No | Yes |  |
 | `type_name` | `String` | No | No |  |
+## TABLE: `dem_table`
+
+| Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
+| :--- | :--- | :--- | :--- | :--- |
+| `rid` | `Integer` | No | Yes |  |
+| `rast` | `Raster` | Yes | No |  |
 ## TABLE: `audit_logs`
 
 | Column Name | SQL Type | Nullable | Primary Key | Foreign Key |

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -5,6 +5,7 @@ from src.models.association import (
 )
 from src.models.audit_log import AuditLog
 from src.models.boundaries import FarmBoundary
+from src.models.dem_table import DemTable
 from src.models.exclusion_rules import SpeciesDependency, SpeciesExclusionRule
 from src.models.farm import Farm
 from src.models.parameters import Parameter
@@ -33,4 +34,5 @@ __all__ = [
     "PlantingEstimate",
     "SpeciesExclusionRule",
     "SpeciesDependency",
+    "DemTable",
 ]

--- a/backend/src/models/dem_table.py
+++ b/backend/src/models/dem_table.py
@@ -1,0 +1,11 @@
+from geoalchemy2 import Raster
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+
+
+class DemTable(Base):
+    __tablename__ = "dem_table"
+
+    rid: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    rast: Mapped[bytes | None] = mapped_column(Raster, nullable=True)

--- a/backend/tests/test_sapling_router.py
+++ b/backend/tests/test_sapling_router.py
@@ -1,0 +1,134 @@
+import pytest
+from geoalchemy2 import WKTElement
+from sqlalchemy import text
+
+from src.models.boundaries import FarmBoundary
+from src.models.farm import Farm
+
+
+@pytest.fixture
+async def setup_farm(async_session, officer_user):  # sapling_estimation router requires OFFICER role or higher
+    await async_session.execute(text("TRUNCATE dem_table RESTART IDENTITY;"))
+    await async_session.execute(
+        text(
+            """
+            INSERT INTO dem_table (rast)
+            VALUES (
+                ST_AddBand(
+                    ST_MakeEmptyRaster(
+                        5, 5,
+                        125, -8.9995,
+                        0.001, -0.001,
+                        0, 0,
+                        4326
+                    ),
+                    1,
+                    '32BF',
+                    100
+                )
+            );
+            """
+        )
+    )
+    await async_session.flush()
+
+    farm = Farm(
+        rainfall_mm=1000,
+        temperature_celsius=25,
+        elevation_m=100,
+        ph=6.5,
+        soil_texture_id=1,
+        area_ha=10,
+        latitude=0,
+        longitude=0,
+        coastal=False,
+        riparian=False,
+        nitrogen_fixing=False,
+        shade_tolerant=False,
+        bank_stabilising=False,
+        slope=5,
+        user_id=officer_user.id,
+    )
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    boundary = FarmBoundary(
+        id=farm.id,
+        external_id=farm.id,
+        boundary=WKTElement(
+            "MULTIPOLYGON (((125 -9, 125 -9.002, 125.002 -9.002, 125.002 -9, 125 -9)))",
+            srid=4326,
+        ),
+    )
+    async_session.add(boundary)
+    await async_session.flush()
+
+    return farm
+
+
+# Cache Miss Test
+@pytest.mark.asyncio
+async def test_cache_miss(
+    async_client,
+    setup_farm,
+    officer_auth_headers,
+):
+    farm = setup_farm
+
+    payload = {
+        "farm_id": farm.id,
+        "spacing_x": 10,
+        "spacing_y": 10,
+        "max_slope": 15,
+    }
+
+    request = await async_client.post(
+        "/sapling_estimation/calculate",
+        json=payload,
+        headers=officer_auth_headers,
+    )
+
+    assert request.status_code == 200  # Request should return 200
+    data = request.json()
+
+    assert "aligned_count" in data
+    assert data["aligned_count"] > 0
+    assert "pre_slope_count" in data
+    assert data["pre_slope_count"] >= data["aligned_count"]
+
+
+# Cache Hit Test
+@pytest.mark.asyncio
+async def test_cache_hit(
+    async_client,
+    setup_farm,
+    officer_auth_headers,
+):
+    farm = setup_farm
+
+    payload = {
+        "farm_id": farm.id,
+        "spacing_x": 10,
+        "spacing_y": 10,
+        "max_slope": 15,
+    }
+
+    # First request creates cache
+    request = await async_client.post(
+        "/sapling_estimation/calculate",
+        json=payload,
+        headers=officer_auth_headers,
+    )
+    cache = request.json()
+
+    # Second request should return cached result
+    request2 = await async_client.post(
+        "/sapling_estimation/calculate",
+        json=payload,
+        headers=officer_auth_headers,
+    )
+    data = request2.json()
+
+    assert request2.status_code == 200  # Second request should return 200
+    assert data == cache  # Second request should return the same result as cache

--- a/backend/tests/test_sapling_router.py
+++ b/backend/tests/test_sapling_router.py
@@ -7,7 +7,7 @@ from src.models.farm import Farm
 
 
 @pytest.fixture
-async def setup_farm(async_session, officer_user):  # sapling_estimation router requires OFFICER role or higher
+async def setup_farm(async_session, test_officer_user):  # sapling_estimation router requires OFFICER role or higher
     await async_session.execute(text("TRUNCATE dem_table RESTART IDENTITY;"))
     await async_session.execute(
         text(
@@ -47,7 +47,7 @@ async def setup_farm(async_session, officer_user):  # sapling_estimation router 
         shade_tolerant=False,
         bank_stabilising=False,
         slope=5,
-        user_id=officer_user.id,
+        user_id=test_officer_user.id,
     )
     async_session.add(farm)
     await async_session.flush()


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
Adds a SQLAlchemy ORM model for `dem_table`, which was originally created via raw SQL in its Alembic migration (#375 ) rather than through the standard `op.create_table()` approach used by all other tables. GeoAlchemy2 supports the `Raster` column type, so this PR brings the models back to a standardized/unified system.
With the model registered in `Base.metadata`, `dem_table` is now captured automatically by `just schema` and `just erd` which have been included.
No migration is required as the table already exists in the database.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
N/A

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
