### PR TITLE
Switch email service from SMTP to Brevo HTTP API

### DIFF
--- a/backend/ERD.md
+++ b/backend/ERD.md
@@ -93,6 +93,20 @@ erDiagram
     FLOAT score_mcda
   }
 
+  soil_ph {
+    INTEGER id PK
+    geometry(MULTIPOLYGON-4326) geometry
+    FLOAT ph "nullable"
+    VARCHAR(100) source "nullable"
+  }
+
+  soil_texture_spatial {
+    INTEGER id PK
+    geometry(MULTIPOLYGON-4326) geometry
+    VARCHAR(100) source "nullable"
+    VARCHAR(100) texture "nullable"
+  }
+
   soil_textures {
     INTEGER id PK
     VARCHAR(15) name UK

--- a/backend/SCHEMA.md
+++ b/backend/SCHEMA.md
@@ -24,12 +24,6 @@
 | :--- | :--- | :--- | :--- | :--- |
 | `id` | `Integer` | No | Yes |  |
 | `type_name` | `String` | No | No |  |
-## TABLE: `dem_table`
-
-| Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
-| :--- | :--- | :--- | :--- | :--- |
-| `rid` | `Integer` | No | Yes |  |
-| `rast` | `Raster` | Yes | No |  |
 ## TABLE: `audit_logs`
 
 | Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
@@ -72,6 +66,12 @@
 | `id` | `Integer` | No | Yes | id |
 | `boundary` | `Geometry` | No | No |  |
 | `external_id` | `Integer` | Yes | No |  |
+## TABLE: `dem_table`
+
+| Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
+| :--- | :--- | :--- | :--- | :--- |
+| `rid` | `Integer` | No | Yes |  |
+| `rast` | `Raster` | Yes | No |  |
 ## TABLE: `species_exclusion_rules`
 
 | Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
@@ -139,12 +139,28 @@
 | `score_mcda` | `Float` | No | No |  |
 | `key_reasons` | `ARRAY` | No | No |  |
 | `created_at` | `DateTime` | No | No |  |
+## TABLE: `soil_ph`
+
+| Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
+| :--- | :--- | :--- | :--- | :--- |
+| `id` | `Integer` | No | Yes |  |
+| `ph` | `Float` | Yes | No |  |
+| `source` | `String` | Yes | No |  |
+| `geometry` | `Geometry` | No | No |  |
 ## TABLE: `soil_textures`
 
 | Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
 | :--- | :--- | :--- | :--- | :--- |
 | `id` | `Integer` | No | Yes |  |
 | `name` | `String` | No | No |  |
+## TABLE: `soil_texture_spatial`
+
+| Column Name | SQL Type | Nullable | Primary Key | Foreign Key |
+| :--- | :--- | :--- | :--- | :--- |
+| `id` | `Integer` | No | Yes |  |
+| `texture` | `String` | Yes | No |  |
+| `source` | `String` | Yes | No |  |
+| `geometry` | `Geometry` | No | No |  |
 ## TABLE: `users`
 
 | Column Name | SQL Type | Nullable | Primary Key | Foreign Key |

--- a/backend/alembic/versions/2025_12_22_1856-enable_postgis_extensions-e3c7a8f2b1d9.py
+++ b/backend/alembic/versions/2025_12_22_1856-enable_postgis_extensions-e3c7a8f2b1d9.py
@@ -1,0 +1,22 @@
+"""Enable PostGIS extensions
+
+Revision ID: e3c7a8f2b1d9
+Revises:
+Create Date: 2025-12-22 18:56:00.000000
+
+"""
+from alembic import op
+
+revision: str = 'e3c7a8f2b1d9'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis")
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis_raster")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/2025_12_22_1857-initial_creation-160313f63d58.py
+++ b/backend/alembic/versions/2025_12_22_1857-initial_creation-160313f63d58.py
@@ -14,7 +14,7 @@ import geoalchemy2
 
 # revision identifiers, used by Alembic.
 revision: str = '160313f63d58'
-down_revision: Union[str, Sequence[str], None] = None
+down_revision: Union[str, Sequence[str], None] = 'e3c7a8f2b1d9'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -22,11 +22,8 @@ class Settings(BaseSettings):
     POSTGRES_PORT: str = Field(default="5432")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
-    smtp_host: str = "localhost"
-    smtp_port: int = 1025
-    smtp_username: str = "test"
-    smtp_password: str = "test"
     smtp_from_email: str = "test@example.com"
+    brevo_api_key: str = ""
     TESTING: bool = False
     REDIS_URL: str = Field(default="")
 

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -10,7 +10,7 @@ All endpoints use JWT tokens for stateless authentication.
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -87,7 +87,7 @@ async def login_for_access_token(
 
 @router.post("/register")
 @limiter.limit("10/minute")
-async def register_user(request: Request, user: UserCreate, db: AsyncSession = Depends(get_db_session)):
+async def register_user(request: Request, user: UserCreate, background_tasks: BackgroundTasks, db: AsyncSession = Depends(get_db_session)):
     """Register a new user account."""
 
     normalized_email = user.email.strip().lower()
@@ -123,7 +123,8 @@ async def register_user(request: Request, user: UserCreate, db: AsyncSession = D
 
     verification_link = f"{settings.frontend_base_url}/verify-email?token={token}"
 
-    await send_email(
+    background_tasks.add_task(
+        send_email,
         subject="Verify your account",
         recipient=db_user.email,
         body=f"Click this link to verify your account:\n{verification_link}",
@@ -233,6 +234,7 @@ async def verify_email(
 @router.post("/forgot-password")
 async def forgot_password(
     request: ForgotPasswordRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db_session),
 ):
     normalized_email = request.email.strip().lower()
@@ -251,7 +253,8 @@ async def forgot_password(
 
         reset_link = f"{settings.frontend_base_url}/reset-password?token={token}"
 
-        await send_email(
+        background_tasks.add_task(
+            send_email,
             subject="Reset your password",
             recipient=user.email,
             body=f"Click this link to reset your password:\n{reset_link}",

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -1,30 +1,27 @@
-import asyncio
-import smtplib
-from email.message import EmailMessage
+import httpx
 
 from src.config import settings
 
 
-# Private sync function that handles SMTP
-def _send_email_sync(subject: str, recipient: str, body: str, html_body: str | None = None) -> None:
-    message = EmailMessage()
-    message["Subject"] = subject
-    message["From"] = settings.smtp_from_email
-    message["To"] = recipient
-    message.set_content(body)
-    if html_body:
-        message.add_alternative(html_body, subtype="html")
-
-    with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10) as server:
-        server.starttls()
-        server.login(settings.smtp_username, settings.smtp_password)
-        server.send_message(message)
-
-
-# Async function that offloads to thread pool to prevent blocking
 async def send_email(subject: str, recipient: str, body: str, html_body: str | None = None) -> None:
     if settings.TESTING:
         print(f"TEST EMAIL to {recipient} | {subject} | {body}")
         return
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _send_email_sync, subject, recipient, body, html_body)
+
+    payload: dict = {
+        "sender": {"name": "Planting Optimisation Tool", "email": settings.smtp_from_email},
+        "to": [{"email": recipient}],
+        "subject": subject,
+        "textContent": body,
+    }
+    if html_body:
+        payload["htmlContent"] = html_body
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.brevo.com/v3/smtp/email",
+            headers={"api-key": settings.brevo_api_key},
+            json=payload,
+            timeout=10,
+        )
+        response.raise_for_status()


### PR DESCRIPTION
## Description
Replaces the SMTP email implementation with Brevo's HTTP API via `httpx`, and moves email sending in the registration and password reset endpoints to FastAPI `BackgroundTasks` so the response is returned immediately rather than waiting for the email to send.

Also adds a PostGIS base migration so that `just render-migrate` enables the required PostGIS extensions automatically on any fresh database, removing the manual setup step when provisioning a new Render database.

Hopefully fixes the email verification failure affecting new user registrations in production.

## Related Issue / Task
Continuation of #417 #446 #467 

## Team / Area
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please specify):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
Truthfully, I don't know if it's going to work. I can't get any information out of Render on the free tier as to why the email verification send is timing out, using the shell is a paid feature :')
It only affects Render, it's not going to break local dev so i'm going to merge it myself.