### PR TITLE
Bug: Fix add rate limiting to password reset endpoints #514

### DIFF
--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -232,12 +232,14 @@ async def verify_email(
 
 
 @router.post("/forgot-password")
+@limiter.limit("10/minute")
 async def forgot_password(
-    request: ForgotPasswordRequest,
+    request: Request,
+    payload: ForgotPasswordRequest,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db_session),
 ):
-    normalized_email = request.email.strip().lower()
+    normalized_email = payload.email.strip().lower()
     result = await db.execute(select(User).filter(User.email == normalized_email))
     user = result.scalar_one_or_none()
 
@@ -264,7 +266,9 @@ async def forgot_password(
 
 
 @router.get("/reset-password/validate")
+@limiter.limit("10/minute")
 async def validate_reset_password_token(
+    request: Request,
     token: str,
     db: AsyncSession = Depends(get_db_session),
 ):
@@ -284,13 +288,15 @@ async def validate_reset_password_token(
 
 
 @router.post("/reset-password")
+@limiter.limit("10/minute")
 async def reset_password(
-    request: ResetPasswordRequest,
+    request: Request,
+    payload: ResetPasswordRequest,
     db: AsyncSession = Depends(get_db_session),
 ):
     token_obj = await get_valid_token(
         db,
-        token=request.token,
+        token=payload.token,
         token_type="password_reset",
     )
 
@@ -309,14 +315,14 @@ async def reset_password(
             detail="User not found",
         )
 
-    validate_password(request.new_password)
-    if verify_password(request.new_password, user.hashed_password):
+    validate_password(payload.new_password)
+    if verify_password(payload.new_password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="New password must be different from the current password",
         )
 
-    user.hashed_password = get_password_hash(request.new_password)
+    user.hashed_password = get_password_hash(payload.new_password)
 
     await mark_token_used(db, token_obj)
     await db.commit()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -690,6 +690,7 @@ version = "0.1.0"
 source = { editable = "../datascience" }
 dependencies = [
     { name = "adjusttext" },
+    { name = "diff-cover" },
     { name = "geopandas" },
     { name = "ipykernel" },
     { name = "joblib" },
@@ -720,6 +721,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "adjusttext", specifier = ">=1.3.0" },
+    { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "geopandas", specifier = ">=1.1.3" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "joblib", specifier = ">=1.5.2" },
@@ -1268,6 +1270,7 @@ name = "gis"
 version = "0.1.0"
 source = { editable = "../gis" }
 dependencies = [
+    { name = "diff-cover" },
     { name = "earthengine-api" },
     { name = "geopandas" },
     { name = "matplotlib" },
@@ -1286,6 +1289,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "earthengine-api", specifier = ">=1.0.0" },
     { name = "geopandas", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },


### PR DESCRIPTION
## Description
Added rate limiting protection to password reset related auth endpoints.
- Added rate limiter to:
  - POST /auth/forgot-password
  - GET /auth/reset-password/validate
  - POST /auth/reset-password
- Added FastAPI Request dependency required by SlowAPI limiter
- Updated endpoint request payload naming for compatibility with rate limiting middleware


## Related Issue / Task
Closes #514 


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
