### PR TITLE
Adding render predeploy for db migrations

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -690,6 +690,7 @@ version = "0.1.0"
 source = { editable = "../datascience" }
 dependencies = [
     { name = "adjusttext" },
+    { name = "diff-cover" },
     { name = "geopandas" },
     { name = "ipykernel" },
     { name = "joblib" },
@@ -720,6 +721,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "adjusttext", specifier = ">=1.3.0" },
+    { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "geopandas", specifier = ">=1.1.3" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "joblib", specifier = ">=1.5.2" },
@@ -1268,6 +1270,7 @@ name = "gis"
 version = "0.1.0"
 source = { editable = "../gis" }
 dependencies = [
+    { name = "diff-cover" },
     { name = "earthengine-api" },
     { name = "geopandas" },
     { name = "matplotlib" },
@@ -1286,6 +1289,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "earthengine-api", specifier = ">=1.0.0" },
     { name = "geopandas", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },

--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,7 @@ projects:
       runtime: docker
       repo: https://github.com/Chameleon-company/Planting-Optimisation-Tool
       plan: free
+      preDeployCommand: cd /app/backend && .venv/bin/alembic upgrade head
       envVars:
       - key: GEE_SERVICE_ACCOUNT
         sync: false


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
Previously on the free render tier we didn't have the preDeployCommand feature, which meant I needed to (remember to) manually migrate the db any time a PR was merged that altered the structure.
Now that we're on the PO's plan, hopefully we should be able to have a preDeployCommand in the blueprint that will autorun migrations before autodeploy.

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Not applicable to a task #

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
As this doesn't impact the repo i'm going to merge it myself.