### PR TITLE
Fix Render preDeployCommand to use absolute path

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ projects:
       runtime: docker
       repo: https://github.com/Chameleon-company/Planting-Optimisation-Tool
       plan: starter
-      preDeployCommand: cd /app/backend && .venv/bin/alembic upgrade head
+      preDeployCommand: /app/backend/.venv/bin/alembic upgrade head
       envVars:
       - key: GEE_SERVICE_ACCOUNT
         sync: false


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
Fixes the `preDeployCommand` in `render.yaml` so Alembic migrations actually run on Render before each deploy.
It works now :)

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Continuation of #523 #522 #521 

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
Will merge as doesn't affect repo