### PR TITLE
Fix farm map test timeout

### DIFF
--- a/frontend/src/test/farmMap.test.tsx
+++ b/frontend/src/test/farmMap.test.tsx
@@ -55,7 +55,7 @@ describe("FarmMap", () => {
       <FarmMap boundary={BOUNDARY} grid={null} optimalAngle={20} spacingY={3} />
     );
     expect(screen.getAllByTestId("polyline").length).toBeGreaterThan(0);
-  });
+  }, 10000);
 
   it("renders no polylines when optimalAngle is null", () => {
     render(<FarmMap boundary={BOUNDARY} grid={null} optimalAngle={null} />);


### PR DESCRIPTION
## Description
The default Vite test time out of 5s appears to be too slow on my computer for the "renders grid overlay lines when optimalAngle is set" in the frontend\src\test\farmMap.test.tsx. I have changed the timeout to 10s. This resolves the issue on my computer. It was taking 7.5s, so 10s gives a little room on slower computers.


## Related Issue / Task
No task raised


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [ ] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [x] Other (please describe): Testing change.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
