### PR TITLE
fix/sapling-estimation-ui

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     POSTGRES_HOST: str = Field(default="localhost")
     POSTGRES_PORT: str = Field(default="5432")
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     smtp_from_email: str = "test@example.com"
     brevo_api_key: str = ""
     TESTING: bool = False

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -86,6 +86,12 @@ async def get_current_user(
         if user_id is None:
             raise credentials_exception
         token_data = TokenData(id=user_id)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Your session has expired. Please log in again.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     except jwt.PyJWTError:
         raise credentials_exception
 

--- a/backend/src/routers/sapling_estimation.py
+++ b/backend/src/routers/sapling_estimation.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/sapling_estimation", tags=["Sapling Calculator"])
     response_model=SaplingEstimationResponse,
     response_model_exclude_none=True,
 )
-@limiter.limit("10/minute", key_func=get_user_id)
+@limiter.limit("20/minute", key_func=get_user_id)
 async def get_sapling_estimation(
     request: Request,
     data: SaplingEstimationRequest,
@@ -55,18 +55,13 @@ async def get_sapling_estimation(
     if not farms:
         raise HTTPException(status_code=404, detail=f"Farm with ID {farm_id} not found.")
 
-    cache_key = f"sapling:{farm_id}:{spacing_x}:{spacing_y}:{max_slope}"
-    cached = await cache.get(cache_key)
-    if cached:
-        return SaplingEstimationResponse(**json.loads(cached))
-
     service = sapling_estimation_service.SaplingEstimationService()
     estimation_data = await service.run_estimation(db, farm_id, spacing_x=spacing_x, spacing_y=spacing_y, max_slope=max_slope)
 
     if not estimation_data:
         raise HTTPException(status_code=404, detail=f"Farm boundary not found for farm_id: {farm_id}")
 
-    await cache.set(cache_key, json.dumps(estimation_data))
+    await cache.invalidate(f"grid:{farm_id}")
     return estimation_data
 
 
@@ -86,7 +81,14 @@ async def get_planting_grid(
     Officers are not directly associated with farms as owners in the current implementation.
     Restrict to owned farms once the RBAC implementation is complete.
     """
+    grid_cache_key = f"grid:{farm_id}"
+    cached = await cache.get(grid_cache_key)
+    if cached:
+        return PlantingGridResponse(**json.loads(cached))
+
     grid = await sapling_estimation_service.get_planting_grid(db, farm_id)
     if not grid["features"]:
         raise HTTPException(status_code=404, detail=f"No planting estimates found for farm {farm_id}.")
+
+    await cache.set(grid_cache_key, json.dumps(grid))
     return grid

--- a/backend/tests/test_sapling_router.py
+++ b/backend/tests/test_sapling_router.py
@@ -100,44 +100,37 @@ async def test_cache_miss(
     assert data["pre_slope_count"] >= data["aligned_count"]
 
 
-# Cache Hit Test
-async def test_cache_hit(
+# Cache Hit Test - /grid caches after first DB fetch; second call should not hit DB
+async def test_grid_cache_hit(
     async_client,
+    async_session,
     setup_farm,
     officer_auth_headers,
 ):
     farm = setup_farm
 
-    payload = {
-        "farm_id": farm.id,
-        "spacing_x": 10,
-        "spacing_y": 10,
-        "max_slope": 15,
-    }
-
-    # First request creates cache by populating redis
-    request = await async_client.post(
-        "/sapling_estimation/calculate",
-        json=payload,
-        headers=officer_auth_headers,
+    estimate = PlantingEstimate(
+        farm_id=farm.id,
+        slope=5.0,
+        geometry=WKTElement("POINT (125.001 -9.001)", srid=4326),
     )
-    assert request.status_code == 200  # First request should return 200
-    cache = request.json()
+    async_session.add(estimate)
+    await async_session.commit()
 
-    # Second request should access and return cached result
-    with patch(  # Patch run_estimation function so it cannot recompute
-        "src.services.sapling_estimation.SaplingEstimationService.run_estimation",
-        side_effect=Exception("Cache hit error: Second request should access cache and not call service"),
+    # First request populates the grid cache from DB
+    response1 = await async_client.get(f"/sapling_estimation/{farm.id}/grid", headers=officer_auth_headers)
+    assert response1.status_code == 200
+    first_result = response1.json()
+
+    # Second request should be served from cache - patch DB access to confirm
+    with patch(
+        "src.services.sapling_estimation.get_planting_grid",
+        side_effect=Exception("Cache hit error: Second /grid request should be served from cache, not DB"),
     ):
-        request2 = await async_client.post(
-            "/sapling_estimation/calculate",
-            json=payload,
-            headers=officer_auth_headers,
-        )
+        response2 = await async_client.get(f"/sapling_estimation/{farm.id}/grid", headers=officer_auth_headers)
 
-    # The second request succeeds if results come from cache/Redis
-    assert request2.status_code == 200  # Second request should return 200
-    assert request2.json() == cache  # Second request should return the same result as cache
+    assert response2.status_code == 200
+    assert response2.json() == first_result
 
 
 async def test_get_planting_grid_returns_geojson(

--- a/docs/bulk-sapling-workflow.md
+++ b/docs/bulk-sapling-workflow.md
@@ -63,7 +63,7 @@ The endpoint uses the following dependencies:
 Rate limiting is applied using:
 
 ```python
-@limiter.limit("10/minute", key_func=get_user_id)
+@limiter.limit("20/minute", key_func=get_user_id)
 ```
 
 The authenticated user ID is passed into the batch estimation service using:

--- a/frontend/src/hooks/useAhp.ts
+++ b/frontend/src/hooks/useAhp.ts
@@ -29,7 +29,7 @@ export function useAhpSpecies() {
       setError(null);
 
       if (!token) {
-        setError("Your session has expired. Please log in again.");
+        setError("Please log in to continue.");
         setIsLoading(false);
         return;
       }
@@ -80,7 +80,7 @@ export function useAhpFactors() {
       setError(null);
 
       if (!token) {
-        setError("Your session has expired. Please log in again.");
+        setError("Please log in to continue.");
         setIsLoading(false);
         return;
       }
@@ -129,7 +129,7 @@ export function useAhpCalculation() {
     setError(null);
 
     if (!token) {
-      setError("Your session has expired. Please log in again.");
+      setError("Please log in to continue.");
       setIsCalculating(false);
       return;
     }

--- a/frontend/src/hooks/useCalculator.ts
+++ b/frontend/src/hooks/useCalculator.ts
@@ -29,7 +29,7 @@ export function useCalculator(farmId: string, params: CalcParams) {
 
       const token = getAccessToken();
       if (!token) {
-        setError("Your session has expired. Please log in again.");
+        setError("Please log in to continue.");
         setIsLoading(false);
         return;
       }

--- a/frontend/src/hooks/useFarmMap.ts
+++ b/frontend/src/hooks/useFarmMap.ts
@@ -28,7 +28,7 @@ export function useFarmMap(farmId: number | null): FarmMapData {
 
       const token = getAccessToken();
       if (!token) {
-        setError("Your session has expired. Please log in again.");
+        setError("Please log in to continue.");
         setIsLoading(false);
         return;
       }

--- a/frontend/src/hooks/useRecommendations.ts
+++ b/frontend/src/hooks/useRecommendations.ts
@@ -40,7 +40,7 @@ export function useRecommendations(farmId: string) {
       const token = getAccessToken();
 
       if (!token) {
-        setError("Your session has expired. Please log in again.");
+        setError("Please log in to continue.");
         setIsLoading(false);
         return;
       }
@@ -85,7 +85,7 @@ export function useRecommendations(farmId: string) {
 
     const token = getAccessToken();
     if (!token) {
-      setError("Session expired. Please log in to download.");
+      setError("Please log in to continue.");
       return;
     }
 

--- a/frontend/src/test/useCalculator.test.tsx
+++ b/frontend/src/test/useCalculator.test.tsx
@@ -104,8 +104,6 @@ describe("useCalculator Hook", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(result.current.error).toBe(
-      "Your session has expired. Please log in again."
-    );
+    expect(result.current.error).toBe("Please log in to continue.");
   });
 });

--- a/frontend/src/test/useFarmMap.test.ts
+++ b/frontend/src/test/useFarmMap.test.ts
@@ -94,8 +94,6 @@ describe("useFarmMap", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(result.current.error).toBe(
-      "Your session has expired. Please log in again."
-    );
+    expect(result.current.error).toBe("Please log in to continue.");
   });
 });


### PR DESCRIPTION
## Description
<!-- Describe what this PR does. Include context and why the change was made. -->
Cache/DB desync bug fix: `/calculate` was caching its summary response, so a second call with the same params returned the cached summary without writing new estimates to the DB. This meant `/grid` would serve stale planting points from the previous run. Removed cache from `/calculate` (mutating operation), moved caching to `/grid` with key `grid:{farm_id}`, and added cache invalidation on each new calculation.

Auth error messages: Distinguished between "not logged in" and "session expired" - frontend hooks show "Please log in to continue." when no token is present in storage, and the backend now returns "Your session has expired. Please log in again." specifically for expired tokens (via `jwt.ExpiredSignatureError` catch before the generic `PyJWTError` handler).

Token expiry: Increased from 15 to 60 minutes, was getting kicked out during demo.

Increased sapling estimation `/calculate` from 10/min to 20/min. Same as previous

## Related Issue / Task
<!-- If this PR addresses an issue, link it here. E.g., "Closes #123" -->
Not applicable

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
