### PR TITLE
Fix: Invalidate recommendation cache on farm update

### DIFF
--- a/backend/src/routers/farm.py
+++ b/backend/src/routers/farm.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src import cache
 from src.database import get_db_session
 from src.dependencies import get_current_user, require_role
 from src.schemas.farm import FarmBoundaryResponse, FarmCreate, FarmRead, FarmUpdate
@@ -137,6 +138,7 @@ async def update_farm(
         farm_data=farm_data,
     )
 
+    await cache.invalidate(f"rec:{farm_id}")
     return updated_farm
 
 


### PR DESCRIPTION
## Description
When a farm was updated, its cached recommendations were not invalidated. This fix adds the line to invalidate the cached recommendation for a farm when it is updated.


## Related Issue / Task
No issue raised.


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
