### PR TITLE
Handle loading and incomplete environmental profile states #195

### DIFF
--- a/frontend/src/components/profile/profileSearchPanel.tsx
+++ b/frontend/src/components/profile/profileSearchPanel.tsx
@@ -12,6 +12,17 @@ interface FarmSearchPanelProps {
   error: string | null;
 }
 
+function hasEnvironmentalProfile(profile: Farm): boolean {
+  return (
+    profile.rainfall_mm != null &&
+    profile.temperature_celsius != null &&
+    profile.elevation_m != null &&
+    profile.ph != null &&
+    profile.slope != null &&
+    Boolean(profile.soil_texture?.name?.trim())
+  );
+}
+
 export default function FarmSearchPanel({
   query,
   setQuery,
@@ -27,6 +38,8 @@ export default function FarmSearchPanel({
 
   const isSearching = query.trim().length > 0;
 
+  const isProfileReady = profile ? hasEnvironmentalProfile(profile) : false;
+
   return (
     <>
       <FarmSearchInput
@@ -39,10 +52,15 @@ export default function FarmSearchPanel({
       {error && <p className="farm-list-empty">{error}</p>}
 
       {isSearching && isLoading && (
-        <p className="farm-list-empty">Loading profile...</p>
+        <div className="profile-status-card" role="status" aria-live="polite">
+          <h2 className="profile-status-title">Loading profile...</h2>
+          <p className="profile-status-message">
+            Retrieving environmental data for this farm.
+          </p>
+        </div>
       )}
 
-      {isSearching && !isLoading && profile && (
+      {isSearching && !isLoading && profile && isProfileReady && (
         <div className="farm-search-result">
           <FarmCard isSearched={true} farm={profile} />
 
@@ -56,6 +74,23 @@ export default function FarmSearchPanel({
               </button>
             )}
           </div>
+        </div>
+      )}
+
+      {isSearching && !isLoading && profile && !isProfileReady && !error && (
+        <div
+          className="profile-status-card profile-status-pending"
+          role="status"
+          aria-live="polite"
+        >
+          <h2 className="profile-status-title">
+            Environmental profile not ready
+          </h2>
+
+          <p className="profile-status-message">
+            This farm is registered, but its environmental data is not available
+            yet. Processing may still be in progress. Please check again later.
+          </p>
         </div>
       )}
 

--- a/frontend/src/pages/profile.css
+++ b/frontend/src/pages/profile.css
@@ -185,3 +185,31 @@
   color: var(--muted);
   font-size: 0.85rem;
 }
+
+/* ============ PROFILE LOADING AND EMPTY STATES ============ */
+
+.profile-status-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  margin: 32px 7%;
+  padding: 32px;
+  text-align: center;
+}
+
+.profile-status-title {
+  color: var(--forest-green);
+  font-size: 1.15rem;
+  margin: 0 0 10px;
+}
+
+.profile-status-message {
+  color: var(--text);
+  line-height: 1.5;
+  margin: 0 auto;
+  max-width: 620px;
+}
+
+.profile-status-pending {
+  border-style: dashed;
+}

--- a/frontend/src/test/profileComponents.test.tsx
+++ b/frontend/src/test/profileComponents.test.tsx
@@ -400,6 +400,30 @@ describe("FarmSearchPanel", () => {
     expect(screen.getByText("Farm #42")).toBeInTheDocument();
   });
 
+  it("shows a pending message when the farm exists but environmental data is incomplete", () => {
+    const incompleteProfile = {
+      ...mockFarm(42),
+      rainfall_mm: null,
+      temperature_celsius: null,
+      elevation_m: null,
+      ph: null,
+      slope: null,
+      soil_texture: null,
+    } as unknown as Farm;
+
+    renderWithRouter(
+      <FarmSearchPanel {...baseProps} query="42" profile={incompleteProfile} />
+    );
+
+    expect(
+      screen.getByText(/environmental profile not ready/i)
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/this farm is registered/i)).toBeInTheDocument();
+
+    expect(screen.queryByText("Farm #42")).not.toBeInTheDocument();
+  });
+
   it("shows 'no profile found' when query is active but no result and user is logged in", () => {
     renderWithRouter(
       <FarmSearchPanel {...baseProps} query="999" profile={null} error={null} />


### PR DESCRIPTION
## Description
Implements sub-issue #195 for US-054 Profile Editor.

- Adds a clear loading state while an environmental profile is being retrieved.
- Adds a pending state when a farm exists but its environmental data is incomplete.
- Keeps API errors and the existing "No profile found" state separate.
- Prevents an incomplete profile from being displayed as a completed profile.
- Adds an automated test for the incomplete-profile state.

## Testing

- `npm run test -- --run`
- `npm run lint:scripts`
- `npm run lint:styles`
- `npm run build`
- `git diff --check`

All checks passed locally.


## Related Issue / Task
Closes #195 


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [ ] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
