### PR TITLE
Add profile edit and regeneration actions

### DIFF
--- a/backend/src/routers/environmental_profile.py
+++ b/backend/src/routers/environmental_profile.py
@@ -63,6 +63,7 @@ async def get_farm_profile(
     await cache.set(cache_key, json.dumps(profile_data))
     return profile_data
 
+
 @router.post(
     "/{farm_id}/regenerate",
     response_model=FarmProfileResponse,
@@ -91,10 +92,7 @@ async def regenerate_farm_profile(
 
     farm = farms[0]
 
-    if (
-        current_user.role == Role.SUPERVISOR
-        and farm.user_id != current_user.id
-    ):
+    if current_user.role == Role.SUPERVISOR and farm.user_id != current_user.id:
         raise HTTPException(
             status_code=403,
             detail="The user does not have adequate permissions.",
@@ -107,9 +105,7 @@ async def regenerate_farm_profile(
         f"rec:{farm_id}",
     )
 
-    service = (
-        environmental_profile_service.EnvironmentalProfileService()
-    )
+    service = environmental_profile_service.EnvironmentalProfileService()
 
     try:
         profile_data = await service.run_environmental_profile(

--- a/backend/src/routers/environmental_profile.py
+++ b/backend/src/routers/environmental_profile.py
@@ -62,3 +62,75 @@ async def get_farm_profile(
 
     await cache.set(cache_key, json.dumps(profile_data))
     return profile_data
+
+@router.post(
+    "/{farm_id}/regenerate",
+    response_model=FarmProfileResponse,
+    response_model_exclude_none=True,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def regenerate_farm_profile(
+    request: Request,
+    farm_id: int,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.SUPERVISOR)),
+):
+    """Regenerates the environmental profile for a farm.
+
+    ADMIN: can regenerate any farm profile.
+    SUPERVISOR: can regenerate only profiles for their own farms.
+    OFFICER: cannot regenerate profiles.
+    """
+    farms = await farm_service.get_farm_by_id(db, [farm_id])
+
+    if not farms:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Farm with ID {farm_id} not found.",
+        )
+
+    farm = farms[0]
+
+    if (
+        current_user.role == Role.SUPERVISOR
+        and farm.user_id != current_user.id
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="The user does not have adequate permissions.",
+        )
+
+    # Remove the old profile and downstream cached results.
+    await cache.invalidate(
+        f"profile:{farm_id}",
+        f"sapling:{farm_id}",
+        f"rec:{farm_id}",
+    )
+
+    service = (
+        environmental_profile_service.EnvironmentalProfileService()
+    )
+
+    try:
+        profile_data = await service.run_environmental_profile(
+            db,
+            farm_id,
+        )
+    except ImputationError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+
+    if not profile_data:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Farm boundary not found for farm_id: {farm_id}",
+        )
+
+    await cache.set(
+        f"profile:{farm_id}",
+        json.dumps(profile_data),
+    )
+
+    return profile_data

--- a/backend/src/routers/farm.py
+++ b/backend/src/routers/farm.py
@@ -139,10 +139,10 @@ async def update_farm(
     )
 
     await cache.invalidate(
-    f"profile:{farm_id}",
-    f"sapling:{farm_id}",
-    f"rec:{farm_id}",
-)
+        f"profile:{farm_id}",
+        f"sapling:{farm_id}",
+        f"rec:{farm_id}",
+    )
     return updated_farm
 
 

--- a/backend/src/routers/farm.py
+++ b/backend/src/routers/farm.py
@@ -138,7 +138,11 @@ async def update_farm(
         farm_data=farm_data,
     )
 
-    await cache.invalidate(f"rec:{farm_id}")
+    await cache.invalidate(
+    f"profile:{farm_id}",
+    f"sapling:{farm_id}",
+    f"rec:{farm_id}",
+)
     return updated_farm
 
 

--- a/backend/tests/test_environmental_profile_router.py
+++ b/backend/tests/test_environmental_profile_router.py
@@ -73,3 +73,153 @@ async def test_cache_hit(
         assert r2.status_code == 200
         mock_run.assert_called_once()
         assert r2.json() == r1.json()
+
+
+async def test_regenerate_profile_admin_success(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_admin_user: User,
+    admin_auth_headers: dict,
+):
+    farm = Farm(user_id=test_admin_user.id, **_FARM_DATA)
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with (
+        patch(
+            "src.routers.environmental_profile.cache.invalidate",
+            new_callable=AsyncMock,
+        ) as mock_invalidate,
+        patch(
+            "src.routers.environmental_profile.cache.set",
+            new_callable=AsyncMock,
+        ) as mock_cache_set,
+        patch(
+            "src.services.environmental_profile."
+            "EnvironmentalProfileService.run_environmental_profile",
+            new_callable=AsyncMock,
+            return_value=_FAKE_PROFILE,
+        ) as mock_run,
+    ):
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=admin_auth_headers,
+        )
+
+        assert response.status_code == 200
+
+        mock_invalidate.assert_awaited_once_with(
+            f"profile:{farm.id}",
+            f"sapling:{farm.id}",
+            f"rec:{farm.id}",
+        )
+
+        mock_run.assert_awaited_once_with(
+            async_session,
+            farm.id,
+        )
+
+        mock_cache_set.assert_awaited_once()
+
+
+async def test_regenerate_profile_supervisor_own_farm_success(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_supervisor_user: User,
+    supervisor_auth_headers: dict,
+):
+    farm = Farm(user_id=test_supervisor_user.id, **_FARM_DATA)
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with (
+        patch(
+            "src.routers.environmental_profile.cache.invalidate",
+            new_callable=AsyncMock,
+        ) as mock_invalidate,
+        patch(
+            "src.routers.environmental_profile.cache.set",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.services.environmental_profile."
+            "EnvironmentalProfileService.run_environmental_profile",
+            new_callable=AsyncMock,
+            return_value=_FAKE_PROFILE,
+        ) as mock_run,
+    ):
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=supervisor_auth_headers,
+        )
+
+        assert response.status_code == 200
+
+        mock_invalidate.assert_awaited_once_with(
+            f"profile:{farm.id}",
+            f"sapling:{farm.id}",
+            f"rec:{farm.id}",
+        )
+
+        mock_run.assert_awaited_once_with(
+            async_session,
+            farm.id,
+        )
+
+async def test_regenerate_profile_supervisor_other_farm_forbidden(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_officer_user: User,
+    supervisor_auth_headers: dict,
+):
+    farm = Farm(user_id=test_officer_user.id, **_FARM_DATA)
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with patch(
+        "src.services.environmental_profile."
+        "EnvironmentalProfileService.run_environmental_profile",
+        new_callable=AsyncMock,
+    ) as mock_run:
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=supervisor_auth_headers,
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == (
+            "The user does not have adequate permissions."
+        )
+
+        mock_run.assert_not_awaited()
+
+async def test_regenerate_profile_officer_forbidden(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_officer_user: User,
+    officer_auth_headers: dict,
+):
+    farm = Farm(user_id=test_officer_user.id, **_FARM_DATA)
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with patch(
+        "src.services.environmental_profile."
+        "EnvironmentalProfileService.run_environmental_profile",
+        new_callable=AsyncMock,
+    ) as mock_run:
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=officer_auth_headers,
+        )
+
+        assert response.status_code == 403
+        mock_run.assert_not_awaited()

--- a/backend/tests/test_environmental_profile_router.py
+++ b/backend/tests/test_environmental_profile_router.py
@@ -97,8 +97,7 @@ async def test_regenerate_profile_admin_success(
             new_callable=AsyncMock,
         ) as mock_cache_set,
         patch(
-            "src.services.environmental_profile."
-            "EnvironmentalProfileService.run_environmental_profile",
+            "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
             new_callable=AsyncMock,
             return_value=_FAKE_PROFILE,
         ) as mock_run,
@@ -146,8 +145,7 @@ async def test_regenerate_profile_supervisor_own_farm_success(
             new_callable=AsyncMock,
         ),
         patch(
-            "src.services.environmental_profile."
-            "EnvironmentalProfileService.run_environmental_profile",
+            "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
             new_callable=AsyncMock,
             return_value=_FAKE_PROFILE,
         ) as mock_run,
@@ -170,6 +168,7 @@ async def test_regenerate_profile_supervisor_own_farm_success(
             farm.id,
         )
 
+
 async def test_regenerate_profile_supervisor_other_farm_forbidden(
     async_client: AsyncClient,
     async_session: AsyncSession,
@@ -183,8 +182,7 @@ async def test_regenerate_profile_supervisor_other_farm_forbidden(
     await async_session.refresh(farm)
 
     with patch(
-        "src.services.environmental_profile."
-        "EnvironmentalProfileService.run_environmental_profile",
+        "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
         new_callable=AsyncMock,
     ) as mock_run:
         response = await async_client.post(
@@ -193,11 +191,10 @@ async def test_regenerate_profile_supervisor_other_farm_forbidden(
         )
 
         assert response.status_code == 403
-        assert response.json()["detail"] == (
-            "The user does not have adequate permissions."
-        )
+        assert response.json()["detail"] == ("The user does not have adequate permissions.")
 
         mock_run.assert_not_awaited()
+
 
 async def test_regenerate_profile_officer_forbidden(
     async_client: AsyncClient,
@@ -212,8 +209,7 @@ async def test_regenerate_profile_officer_forbidden(
     await async_session.refresh(farm)
 
     with patch(
-        "src.services.environmental_profile."
-        "EnvironmentalProfileService.run_environmental_profile",
+        "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
         new_callable=AsyncMock,
     ) as mock_run:
         response = await async_client.post(

--- a/backend/tests/test_environmental_profile_router.py
+++ b/backend/tests/test_environmental_profile_router.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.farm import Farm
 from src.models.user import User
+from src.services.environmental_profile import ImputationError
 
 _FARM_DATA = {
     "rainfall_mm": 1500,
@@ -219,3 +220,110 @@ async def test_regenerate_profile_officer_forbidden(
 
         assert response.status_code == 403
         mock_run.assert_not_awaited()
+
+
+async def test_regenerate_profile_missing_farm_returns_404(
+    async_client: AsyncClient,
+    admin_auth_headers: dict,
+):
+    response = await async_client.post(
+        "/profile/999999/regenerate",
+        headers=admin_auth_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == (
+        "Farm with ID 999999 not found."
+    )
+
+
+async def test_regenerate_profile_imputation_error_returns_503(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_supervisor_user: User,
+    supervisor_auth_headers: dict,
+):
+    farm = Farm(
+        user_id=test_supervisor_user.id,
+        **_FARM_DATA,
+    )
+
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with (
+        patch(
+            "src.routers.environmental_profile.cache.invalidate",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.routers.environmental_profile.cache.set",
+            new_callable=AsyncMock,
+        ) as mock_cache_set,
+        patch(
+            "src.services.environmental_profile."
+            "EnvironmentalProfileService.run_environmental_profile",
+            new_callable=AsyncMock,
+            side_effect=ImputationError(
+                "Environmental profile generation failed."
+            ),
+        ),
+    ):
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=supervisor_auth_headers,
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "Environmental profile generation failed."
+    )
+
+    mock_cache_set.assert_not_awaited()
+
+
+async def test_regenerate_profile_empty_result_returns_404(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    setup_soil_texture,
+    test_officer_user: User,
+    admin_auth_headers: dict,
+):
+    farm = Farm(
+        user_id=test_officer_user.id,
+        **_FARM_DATA,
+    )
+
+    async_session.add(farm)
+    await async_session.flush()
+    await async_session.refresh(farm)
+
+    with (
+        patch(
+            "src.routers.environmental_profile.cache.invalidate",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.routers.environmental_profile.cache.set",
+            new_callable=AsyncMock,
+        ) as mock_cache_set,
+        patch(
+            "src.services.environmental_profile."
+            "EnvironmentalProfileService.run_environmental_profile",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        response = await async_client.post(
+            f"/profile/{farm.id}/regenerate",
+            headers=admin_auth_headers,
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == (
+        f"Farm boundary not found for farm_id: {farm.id}"
+    )
+
+    mock_cache_set.assert_not_awaited()

--- a/backend/tests/test_environmental_profile_router.py
+++ b/backend/tests/test_environmental_profile_router.py
@@ -232,9 +232,7 @@ async def test_regenerate_profile_missing_farm_returns_404(
     )
 
     assert response.status_code == 404
-    assert response.json()["detail"] == (
-        "Farm with ID 999999 not found."
-    )
+    assert response.json()["detail"] == ("Farm with ID 999999 not found.")
 
 
 async def test_regenerate_profile_imputation_error_returns_503(
@@ -263,12 +261,9 @@ async def test_regenerate_profile_imputation_error_returns_503(
             new_callable=AsyncMock,
         ) as mock_cache_set,
         patch(
-            "src.services.environmental_profile."
-            "EnvironmentalProfileService.run_environmental_profile",
+            "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
             new_callable=AsyncMock,
-            side_effect=ImputationError(
-                "Environmental profile generation failed."
-            ),
+            side_effect=ImputationError("Environmental profile generation failed."),
         ),
     ):
         response = await async_client.post(
@@ -277,9 +272,7 @@ async def test_regenerate_profile_imputation_error_returns_503(
         )
 
     assert response.status_code == 503
-    assert response.json()["detail"] == (
-        "Environmental profile generation failed."
-    )
+    assert response.json()["detail"] == ("Environmental profile generation failed.")
 
     mock_cache_set.assert_not_awaited()
 
@@ -310,8 +303,7 @@ async def test_regenerate_profile_empty_result_returns_404(
             new_callable=AsyncMock,
         ) as mock_cache_set,
         patch(
-            "src.services.environmental_profile."
-            "EnvironmentalProfileService.run_environmental_profile",
+            "src.services.environmental_profile.EnvironmentalProfileService.run_environmental_profile",
             new_callable=AsyncMock,
             return_value=None,
         ),
@@ -322,8 +314,6 @@ async def test_regenerate_profile_empty_result_returns_404(
         )
 
     assert response.status_code == 404
-    assert response.json()["detail"] == (
-        f"Farm boundary not found for farm_id: {farm.id}"
-    )
+    assert response.json()["detail"] == (f"Farm boundary not found for farm_id: {farm.id}")
 
     mock_cache_set.assert_not_awaited()

--- a/frontend/src/components/profile/profileSearchPanel.tsx
+++ b/frontend/src/components/profile/profileSearchPanel.tsx
@@ -1,8 +1,8 @@
 import FarmSearchInput from "./profileSearchInput";
 import FarmCard from "./profileCard";
-import { Farm } from "@/hooks/useUserProfiles";
-import { useNavigate } from "react-router-dom";
+
 import { useAuth } from "@/contexts/AuthContext";
+import type { Farm } from "@/hooks/useUserProfiles";
 
 interface FarmSearchPanelProps {
   query: string;
@@ -10,6 +10,11 @@ interface FarmSearchPanelProps {
   profile: Farm | null;
   isLoading: boolean;
   error: string | null;
+  onEdit?: () => void;
+  onRegenerate?: () => void;
+  isRegenerating?: boolean;
+  actionError?: string | null;
+  actionMessage?: string | null;
 }
 
 function hasEnvironmentalProfile(profile: Farm): boolean {
@@ -29,16 +34,46 @@ export default function FarmSearchPanel({
   profile,
   isLoading,
   error,
+  onEdit,
+  onRegenerate,
+  isRegenerating = false,
+  actionError = null,
+  actionMessage = null,
 }: FarmSearchPanelProps) {
-  const navigate = useNavigate();
   const { user } = useAuth();
+
   const canEdit = user?.role === "supervisor" || user?.role === "admin";
+
+  const canManageProfile = canEdit && Boolean(onEdit) && Boolean(onRegenerate);
 
   const handleClear = () => setQuery("");
 
   const isSearching = query.trim().length > 0;
 
   const isProfileReady = profile ? hasEnvironmentalProfile(profile) : false;
+
+  const actionControls =
+    canManageProfile && profile ? (
+      <div className="profile-action-row">
+        <button
+          type="button"
+          className="btn-secondary"
+          onClick={onEdit}
+          disabled={isRegenerating}
+        >
+          Edit
+        </button>
+
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={onRegenerate}
+          disabled={isRegenerating}
+        >
+          {isRegenerating ? "Regenerating..." : "Regenerate"}
+        </button>
+      </div>
+    ) : null;
 
   return (
     <>
@@ -51,9 +86,25 @@ export default function FarmSearchPanel({
 
       {error && <p className="farm-list-empty">{error}</p>}
 
+      {actionError && (
+        <p className="profile-action-message profile-action-error" role="alert">
+          {actionError}
+        </p>
+      )}
+
+      {actionMessage && !actionError && (
+        <p
+          className="profile-action-message profile-action-success"
+          role="status"
+        >
+          {actionMessage}
+        </p>
+      )}
+
       {isSearching && isLoading && (
         <div className="profile-status-card" role="status" aria-live="polite">
           <h2 className="profile-status-title">Loading profile...</h2>
+
           <p className="profile-status-message">
             Retrieving environmental data for this farm.
           </p>
@@ -63,35 +114,30 @@ export default function FarmSearchPanel({
       {isSearching && !isLoading && profile && isProfileReady && (
         <div className="farm-search-result">
           <FarmCard isSearched={true} farm={profile} />
-
-          <div className="farm-bottom-row">
-            {canEdit && (
-              <button
-                className="btn-primary"
-                onClick={() => navigate("/farms")}
-              >
-                Manage
-              </button>
-            )}
-          </div>
+          {actionControls}
         </div>
       )}
 
       {isSearching && !isLoading && profile && !isProfileReady && !error && (
-        <div
-          className="profile-status-card profile-status-pending"
-          role="status"
-          aria-live="polite"
-        >
-          <h2 className="profile-status-title">
-            Environmental profile not ready
-          </h2>
+        <>
+          <div
+            className="profile-status-card profile-status-pending"
+            role="status"
+            aria-live="polite"
+          >
+            <h2 className="profile-status-title">
+              Environmental profile not ready
+            </h2>
 
-          <p className="profile-status-message">
-            This farm is registered, but its environmental data is not available
-            yet. Processing may still be in progress. Please check again later.
-          </p>
-        </div>
+            <p className="profile-status-message">
+              This farm is registered, but its environmental data is not
+              available yet. Processing may still be in progress. Please check
+              again later.
+            </p>
+          </div>
+
+          {actionControls}
+        </>
       )}
 
       {isSearching && !isLoading && !profile && !error && (
@@ -99,6 +145,7 @@ export default function FarmSearchPanel({
           {!user && (
             <p className="farm-list-empty">You must be logged in to search.</p>
           )}
+
           {user && <p className="farm-list-empty">No profile found.</p>}
         </>
       )}

--- a/frontend/src/hooks/useProfileActions.ts
+++ b/frontend/src/hooks/useProfileActions.ts
@@ -1,0 +1,110 @@
+import { useCallback, useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
+
+const API_BASE = import.meta.env.VITE_API_URL;
+
+export interface RegeneratedProfile {
+  id?: number;
+  status: string;
+  data_source?: string;
+  rainfall_mm?: number;
+  temperature_celsius?: number;
+  elevation_m?: number;
+  ph?: number;
+  slope?: number;
+  soil_texture_id?: number;
+  soil_texture?: string;
+  area_ha?: number;
+  latitude?: number;
+  longitude?: number;
+  coastal?: boolean;
+  riparian?: boolean;
+  nitrogen_fixing?: boolean;
+  shade_tolerant?: boolean;
+  bank_stabilising?: boolean;
+}
+
+async function getErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+
+    if (typeof data.detail === "string") {
+      return data.detail;
+    }
+  } catch {
+    // Use the fallback message when the response is not JSON.
+  }
+
+  return `Request failed (${response.status})`;
+}
+
+export function useProfileActions() {
+  const { getAccessToken } = useAuth();
+
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  const clearActionFeedback = useCallback(() => {
+    setActionError(null);
+    setActionMessage(null);
+  }, []);
+
+  const regenerateProfile = useCallback(
+    async (farmId: number): Promise<RegeneratedProfile> => {
+      const token = getAccessToken();
+
+      if (!token) {
+        const message = "You must be logged in.";
+        setActionError(message);
+        throw new Error(message);
+      }
+
+      setIsRegenerating(true);
+      setActionError(null);
+      setActionMessage(null);
+
+      try {
+        const response = await fetch(
+          `${API_BASE}/profile/${farmId}/regenerate`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/json",
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(await getErrorMessage(response));
+        }
+
+        const regeneratedProfile: RegeneratedProfile = await response.json();
+
+        setActionMessage("Environmental profile regenerated successfully.");
+
+        return regeneratedProfile;
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to regenerate the environmental profile.";
+
+        setActionError(message);
+        throw new Error(message);
+      } finally {
+        setIsRegenerating(false);
+      }
+    },
+    [getAccessToken]
+  );
+
+  return {
+    regenerateProfile,
+    isRegenerating,
+    actionError,
+    actionMessage,
+    clearActionFeedback,
+  };
+}

--- a/frontend/src/hooks/useSearchProfiles.ts
+++ b/frontend/src/hooks/useSearchProfiles.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { Farm } from "./useUserProfiles";
 
@@ -12,51 +12,69 @@ export function useSearchProfiles(query: string) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchProfile = useCallback(async () => {
     if (!query.trim() || !token) {
       setProfile(null);
       setError(null);
+      setIsLoading(false);
       return;
     }
 
-    const fetchProfile = async () => {
-      setIsLoading(true);
-      setError(null);
+    setIsLoading(true);
+    setError(null);
 
-      try {
-        const res = await fetch(`${API_BASE}/farms/${query}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/json",
-          },
-        });
+    try {
+      const res = await fetch(`${API_BASE}/farms/${query}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+      });
 
-        if (!res.ok) {
-          let errorMessage = "Something went wrong";
-          try {
-            const errorData = await res.json();
-            if (typeof errorData.detail === "string") {
-              errorMessage = errorData.detail;
-            }
-          } catch {
-            errorMessage = await res.text();
+      if (!res.ok) {
+        let errorMessage = "Something went wrong";
+
+        try {
+          const errorData = await res.json();
+
+          if (typeof errorData.detail === "string") {
+            errorMessage = errorData.detail;
           }
-          throw new Error(errorMessage);
+        } catch {
+          errorMessage = `Failed to load profile (${res.status})`;
         }
 
-        const data = await res.json();
-        data.id = data.id ?? Number(query);
-        setProfile(data);
-      } catch (err: unknown) {
-        setProfile(null);
-        setError(err instanceof Error ? err.message : "Unexpected error");
-      } finally {
-        setIsLoading(false);
+        throw new Error(errorMessage);
       }
-    };
 
-    fetchProfile();
+      const data: Farm = await res.json();
+
+      setProfile({
+        ...data,
+        id: data.id ?? Number(query),
+      });
+    } catch (err: unknown) {
+      setProfile(null);
+      setError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setIsLoading(false);
+    }
   }, [query, token]);
 
-  return { profile, isLoading, error };
+  useEffect(() => {
+    void fetchProfile();
+  }, [fetchProfile]);
+
+  const replaceProfile = useCallback((nextProfile: Farm) => {
+    setProfile(nextProfile);
+    setError(null);
+  }, []);
+
+  return {
+    profile,
+    isLoading,
+    error,
+    refetch: fetchProfile,
+    replaceProfile,
+  };
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,22 +1,31 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
-import "./profile.css";
+import { useSearchParams } from "react-router-dom";
+
 import ProfileHeader from "@/components/profile/profileHeader";
 import FarmList from "@/components/profile/profileFarms";
 import FarmSearchPanel from "@/components/profile/profileSearchPanel";
+import EditFarmModal from "@/components/farmManagement/farmsEditModal";
 
-import { useUserProfiles } from "../hooks/useUserProfiles";
-import { useSearchProfiles } from "../hooks/useSearchProfiles";
 import { useAuth } from "@/contexts/AuthContext";
-import { useSearchParams } from "react-router-dom";
+import { Farm, useUserProfiles } from "@/hooks/useUserProfiles";
+import { useSearchProfiles } from "@/hooks/useSearchProfiles";
+import { FarmUpdatePayload, useFarms } from "@/hooks/useFarms";
+import { useProfileActions } from "@/hooks/useProfileActions";
+
+import "./profile.css";
+import "./farmManagement.css";
 
 function ProfilePage() {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
+
   const [query, setQuery] = useState(searchParams.get("farmId") ?? "");
   const [debouncedQuery, setDebouncedQuery] = useState(
     searchParams.get("farmId") ?? ""
   );
+  const [editingFarm, setEditingFarm] = useState<Farm | null>(null);
+  const [editMessage, setEditMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -33,7 +42,82 @@ function ProfilePage() {
     profile,
     isLoading: isProfileLoading,
     error,
+    refetch,
+    replaceProfile,
   } = useSearchProfiles(debouncedQuery);
+
+  const { updateFarm } = useFarms();
+
+  const {
+    regenerateProfile,
+    isRegenerating,
+    actionError,
+    actionMessage,
+    clearActionFeedback,
+  } = useProfileActions();
+
+  useEffect(() => {
+    clearActionFeedback();
+    setEditMessage(null);
+  }, [query, clearActionFeedback]);
+
+  const handleEdit = () => {
+    if (!profile) return;
+
+    clearActionFeedback();
+    setEditMessage(null);
+    setEditingFarm(profile);
+  };
+
+  const handleEditSuccess = async (
+    farmId: number,
+    payload: FarmUpdatePayload
+  ) => {
+    const updated = await updateFarm(farmId, payload);
+
+    if (!updated) {
+      throw new Error("Failed to update farm.");
+    }
+
+    setEditingFarm(null);
+    await refetch();
+    setEditMessage("Environmental profile updated successfully.");
+  };
+
+  const handleRegenerate = async () => {
+    if (!profile) return;
+
+    setEditMessage(null);
+
+    try {
+      const regenerated = await regenerateProfile(profile.id);
+
+      replaceProfile({
+        ...profile,
+        id: regenerated.id ?? profile.id,
+        rainfall_mm: regenerated.rainfall_mm ?? profile.rainfall_mm,
+        temperature_celsius:
+          regenerated.temperature_celsius ?? profile.temperature_celsius,
+        elevation_m: regenerated.elevation_m ?? profile.elevation_m,
+        ph: regenerated.ph ?? profile.ph,
+        slope: regenerated.slope ?? profile.slope,
+        area_ha: regenerated.area_ha ?? profile.area_ha,
+        latitude: regenerated.latitude ?? profile.latitude,
+        longitude: regenerated.longitude ?? profile.longitude,
+        coastal: regenerated.coastal ?? profile.coastal,
+        riparian: regenerated.riparian ?? profile.riparian,
+        nitrogen_fixing: regenerated.nitrogen_fixing ?? profile.nitrogen_fixing,
+        shade_tolerant: regenerated.shade_tolerant ?? profile.shade_tolerant,
+        bank_stabilising:
+          regenerated.bank_stabilising ?? profile.bank_stabilising,
+        soil_texture: regenerated.soil_texture?.trim()
+          ? { name: regenerated.soil_texture }
+          : profile.soil_texture,
+      });
+    } catch {
+      // useProfileActions exposes the error through actionError.
+    }
+  };
 
   const isSearching = query.trim().length > 0;
 
@@ -51,6 +135,11 @@ function ProfilePage() {
         profile={profile}
         isLoading={isProfileLoading}
         error={error}
+        onEdit={handleEdit}
+        onRegenerate={handleRegenerate}
+        isRegenerating={isRegenerating}
+        actionError={actionError}
+        actionMessage={actionMessage ?? editMessage}
       />
 
       {!isSearching && (
@@ -60,6 +149,14 @@ function ProfilePage() {
           page={page}
           totalPages={totalPages}
           setPage={setPage}
+        />
+      )}
+
+      {editingFarm && (
+        <EditFarmModal
+          farm={editingFarm}
+          onClose={() => setEditingFarm(null)}
+          onSuccess={handleEditSuccess}
         />
       )}
     </div>

--- a/frontend/src/pages/profile.css
+++ b/frontend/src/pages/profile.css
@@ -213,3 +213,48 @@
 .profile-status-pending {
   border-style: dashed;
 }
+
+/* ============ PROFILE EDIT AND REGENERATE ACTIONS ============ */
+
+.profile-action-row {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 0 7% 32px;
+}
+
+.profile-action-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.profile-action-message {
+  border-radius: 8px;
+  margin: 20px 7% 0;
+  padding: 12px 18px;
+  text-align: center;
+}
+
+.profile-action-success {
+  background: var(--tint-light);
+  border: 1px solid var(--forest-green);
+  color: var(--black-forest);
+}
+
+.profile-action-error {
+  background: color-mix(in srgb, var(--danger) 12%, var(--bg));
+  border: 1px solid var(--danger);
+  color: var(--danger-dark);
+}
+
+@media (max-width: 480px) {
+  .profile-action-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .profile-action-row button {
+    width: 100%;
+  }
+}

--- a/frontend/src/test/profileComponents.test.tsx
+++ b/frontend/src/test/profileComponents.test.tsx
@@ -451,6 +451,121 @@ describe("FarmSearchPanel", () => {
     expect(screen.getByText(/must be logged in/i)).toBeInTheDocument();
   });
 
+  it("shows Edit and Regenerate actions for an admin", () => {
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        query="42"
+        profile={mockFarm(42)}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: /^regenerate$/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows Edit and Regenerate actions for a supervisor", () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        name: "Supervisor User",
+        role: "supervisor",
+      },
+    });
+
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        query="42"
+        profile={mockFarm(42)}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: /^regenerate$/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show profile actions for an officer", () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        name: "Officer User",
+        role: "officer",
+      },
+    });
+
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        query="42"
+        profile={mockFarm(42)}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /^edit$/i })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: /^regenerate$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables profile actions while regeneration is running", () => {
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        query="42"
+        profile={mockFarm(42)}
+        onEdit={vi.fn()}
+        onRegenerate={vi.fn()}
+        isRegenerating={true}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", { name: /regenerating/i })
+    ).toBeDisabled();
+  });
+
+  it("shows action success feedback", () => {
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        actionMessage="Environmental profile regenerated successfully."
+      />
+    );
+
+    expect(
+      screen.getByText(/profile regenerated successfully/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows action error feedback", () => {
+    renderWithRouter(
+      <FarmSearchPanel
+        {...baseProps}
+        actionError="Failed to regenerate the environmental profile."
+      />
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /failed to regenerate/i
+    );
+  });
+
   it("does not show any search result state when query is empty", () => {
     renderWithRouter(<FarmSearchPanel {...baseProps} query="" />);
     // With no active query none of the result/empty/loading states should appear

--- a/frontend/src/test/profilePage194.test.tsx
+++ b/frontend/src/test/profilePage194.test.tsx
@@ -1,0 +1,461 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Farm } from "@/hooks/useUserProfiles";
+import type { FarmUpdatePayload } from "@/hooks/useFarms";
+
+import ProfilePage from "@/pages/ProfilePage";
+
+const mocks = vi.hoisted(() => ({
+  useUserProfiles: vi.fn(),
+  useSearchProfiles: vi.fn(),
+  useFarms: vi.fn(),
+  useProfileActions: vi.fn(),
+  refetch: vi.fn(),
+  replaceProfile: vi.fn(),
+  updateFarm: vi.fn(),
+  regenerateProfile: vi.fn(),
+  clearActionFeedback: vi.fn(),
+}));
+
+vi.mock("react-helmet-async", () => ({
+  Helmet: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      name: "Admin User",
+      email: "admin@example.com",
+      role: "admin",
+      farms: [],
+    },
+    getAccessToken: () => "test-token",
+  }),
+}));
+
+vi.mock("@/hooks/useUserProfiles", () => ({
+  useUserProfiles: () => mocks.useUserProfiles(),
+}));
+
+vi.mock("@/hooks/useSearchProfiles", () => ({
+  useSearchProfiles: (query: string) => mocks.useSearchProfiles(query),
+}));
+
+vi.mock("@/hooks/useFarms", () => ({
+  useFarms: () => mocks.useFarms(),
+}));
+
+vi.mock("@/hooks/useProfileActions", () => ({
+  useProfileActions: () => mocks.useProfileActions(),
+}));
+
+vi.mock("@/components/profile/profileHeader", () => ({
+  default: ({
+    userName,
+    farmCount,
+  }: {
+    userName?: string;
+    farmCount: number;
+  }) => (
+    <header>
+      Environmental Profile - {userName} - {farmCount}
+    </header>
+  ),
+}));
+
+vi.mock("@/components/profile/profileFarms", () => ({
+  default: () => <div data-testid="farm-list">Farm list</div>,
+}));
+
+interface SearchPanelProps {
+  query: string;
+  setQuery: (query: string) => void;
+  profile: Farm | null;
+  onEdit?: () => void;
+  onRegenerate?: () => void;
+  isRegenerating?: boolean;
+  actionError?: string | null;
+  actionMessage?: string | null;
+}
+
+vi.mock("@/components/profile/profileSearchPanel", () => ({
+  default: ({
+    query,
+    setQuery,
+    profile,
+    onEdit,
+    onRegenerate,
+    isRegenerating,
+    actionError,
+    actionMessage,
+  }: SearchPanelProps) => (
+    <section>
+      <div data-testid="current-query">{query}</div>
+
+      <div data-testid="displayed-profile">
+        {profile
+          ? `${profile.id}:${profile.rainfall_mm}:${profile.soil_texture.name}`
+          : "none"}
+      </div>
+
+      <button type="button" onClick={onEdit}>
+        Panel Edit
+      </button>
+
+      <button type="button" onClick={onRegenerate}>
+        {isRegenerating ? "Panel Regenerating" : "Panel Regenerate"}
+      </button>
+
+      <button type="button" onClick={() => setQuery("")}>
+        Clear query
+      </button>
+
+      {actionMessage && <p data-testid="action-message">{actionMessage}</p>}
+
+      {actionError && <p data-testid="action-error">{actionError}</p>}
+    </section>
+  ),
+}));
+
+interface EditModalProps {
+  farm: Farm;
+  onClose: () => void;
+  onSuccess: (farmId: number, payload: FarmUpdatePayload) => Promise<void>;
+}
+
+vi.mock("@/components/farmManagement/farmsEditModal", () => ({
+  default: ({ farm, onClose, onSuccess }: EditModalProps) => (
+    <div role="dialog" aria-label="Edit farm modal">
+      <span>Edit farm {farm.id}</span>
+
+      <button
+        type="button"
+        onClick={() => {
+          void onSuccess(farm.id, {
+            rainfall_mm: 2000,
+          }).catch(() => undefined);
+        }}
+      >
+        Save modal
+      </button>
+
+      <button type="button" onClick={onClose}>
+        Close modal
+      </button>
+    </div>
+  ),
+}));
+
+const FARM: Farm = {
+  id: 42,
+  rainfall_mm: 800,
+  temperature_celsius: 22,
+  elevation_m: 150,
+  ph: 6.5,
+  soil_texture: { name: "Loam" },
+  area_ha: 12.345,
+  latitude: -37.12345,
+  longitude: 144.12345,
+  coastal: true,
+  riparian: false,
+  nitrogen_fixing: true,
+  shade_tolerant: false,
+  bank_stabilising: false,
+  slope: 3.75,
+  agroforestry_type: [],
+} as Farm;
+
+function renderPage(route = "/profile?farmId=42") {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <ProfilePage />
+    </MemoryRouter>
+  );
+}
+
+describe("ProfilePage #194 interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.useUserProfiles.mockReturnValue({
+      farms: [FARM],
+      isLoading: false,
+      error: null,
+      page: 0,
+      setPage: vi.fn(),
+      totalFarms: 1,
+      totalPages: 1,
+    });
+
+    mocks.useSearchProfiles.mockReturnValue({
+      profile: FARM,
+      isLoading: false,
+      error: null,
+      refetch: mocks.refetch,
+      replaceProfile: mocks.replaceProfile,
+    });
+
+    mocks.useFarms.mockReturnValue({
+      updateFarm: mocks.updateFarm,
+    });
+
+    mocks.useProfileActions.mockReturnValue({
+      regenerateProfile: mocks.regenerateProfile,
+      isRegenerating: false,
+      actionError: null,
+      actionMessage: null,
+      clearActionFeedback: mocks.clearActionFeedback,
+    });
+
+    mocks.updateFarm.mockResolvedValue(true);
+    mocks.refetch.mockResolvedValue(undefined);
+
+    mocks.regenerateProfile.mockResolvedValue({
+      id: 42,
+      status: "success",
+      rainfall_mm: 1500,
+      temperature_celsius: 25,
+      elevation_m: 300,
+      ph: 7,
+      slope: 5,
+      soil_texture: "Sandy loam",
+      area_ha: 13,
+      latitude: -38,
+      longitude: 145,
+      coastal: false,
+      riparian: true,
+      nitrogen_fixing: false,
+      shade_tolerant: true,
+      bank_stabilising: true,
+    });
+  });
+
+  it("opens and closes the existing farm edit modal", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Panel Edit" }));
+
+    expect(
+      screen.getByRole("dialog", {
+        name: "Edit farm modal",
+      })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close modal" }));
+
+    expect(
+      screen.queryByRole("dialog", {
+        name: "Edit farm modal",
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it("updates and refreshes the searched profile after editing", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Panel Edit" }));
+
+    await user.click(screen.getByRole("button", { name: "Save modal" }));
+
+    await waitFor(() => {
+      expect(mocks.updateFarm).toHaveBeenCalledWith(42, {
+        rainfall_mm: 2000,
+      });
+    });
+
+    expect(mocks.refetch).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", {
+          name: "Edit farm modal",
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("action-message")).toHaveTextContent(
+      "Environmental profile updated successfully."
+    );
+  });
+
+  it("keeps the modal open when the farm update fails", async () => {
+    mocks.updateFarm.mockResolvedValue(false);
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Panel Edit" }));
+
+    await user.click(screen.getByRole("button", { name: "Save modal" }));
+
+    await waitFor(() => {
+      expect(mocks.updateFarm).toHaveBeenCalled();
+    });
+
+    expect(mocks.refetch).not.toHaveBeenCalled();
+
+    expect(
+      screen.getByRole("dialog", {
+        name: "Edit farm modal",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("regenerates and replaces the displayed profile", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Panel Regenerate",
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.regenerateProfile).toHaveBeenCalledWith(42);
+    });
+
+    expect(mocks.replaceProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        rainfall_mm: 1500,
+        temperature_celsius: 25,
+        elevation_m: 300,
+        ph: 7,
+        slope: 5,
+        area_ha: 13,
+        latitude: -38,
+        longitude: 145,
+        coastal: false,
+        riparian: true,
+        nitrogen_fixing: false,
+        shade_tolerant: true,
+        bank_stabilising: true,
+        soil_texture: {
+          name: "Sandy loam",
+        },
+      })
+    );
+  });
+
+  it("retains existing values when regeneration omits optional values", async () => {
+    mocks.regenerateProfile.mockResolvedValue({
+      status: "success",
+      soil_texture: "   ",
+    });
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Panel Regenerate",
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.replaceProfile).toHaveBeenCalled();
+    });
+
+    expect(mocks.replaceProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: FARM.id,
+        rainfall_mm: FARM.rainfall_mm,
+        temperature_celsius: FARM.temperature_celsius,
+        elevation_m: FARM.elevation_m,
+        ph: FARM.ph,
+        slope: FARM.slope,
+        area_ha: FARM.area_ha,
+        latitude: FARM.latitude,
+        longitude: FARM.longitude,
+        coastal: FARM.coastal,
+        riparian: FARM.riparian,
+        nitrogen_fixing: FARM.nitrogen_fixing,
+        shade_tolerant: FARM.shade_tolerant,
+        bank_stabilising: FARM.bank_stabilising,
+        soil_texture: FARM.soil_texture,
+      })
+    );
+  });
+
+  it("does not replace the profile when regeneration fails", async () => {
+    mocks.regenerateProfile.mockRejectedValue(new Error("Regeneration failed"));
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Panel Regenerate",
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.regenerateProfile).toHaveBeenCalledWith(42);
+    });
+
+    expect(mocks.replaceProfile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when Edit or Regenerate is triggered without a profile", async () => {
+    mocks.useSearchProfiles.mockReturnValue({
+      profile: null,
+      isLoading: false,
+      error: null,
+      refetch: mocks.refetch,
+      replaceProfile: mocks.replaceProfile,
+    });
+
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Panel Edit" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Panel Regenerate",
+      })
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    expect(mocks.regenerateProfile).not.toHaveBeenCalled();
+
+    expect(mocks.replaceProfile).not.toHaveBeenCalled();
+  });
+
+  it("clears action feedback when the page or query changes", () => {
+    renderPage();
+
+    expect(mocks.clearActionFeedback).toHaveBeenCalled();
+
+    expect(screen.getByTestId("current-query")).toHaveTextContent("42");
+  });
+
+  it("shows the normal farm list after the search is cleared", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(screen.queryByTestId("farm-list")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear query" }));
+
+    expect(screen.getByTestId("farm-list")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/useProfileActions.test.ts
+++ b/frontend/src/test/useProfileActions.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProfileActions } from "@/hooks/useProfileActions";
+
+const { mockGetAccessToken } = vi.hoisted(() => ({
+  mockGetAccessToken: vi.fn(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+const fetchMock = vi.fn();
+
+function createResponse(
+  ok: boolean,
+  status: number,
+  body?: unknown,
+  rejectJson = false
+): Response {
+  return {
+    ok,
+    status,
+    json: rejectJson
+      ? vi.fn().mockRejectedValue(new Error("Invalid JSON"))
+      : vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("useProfileActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue("test-token");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("regenerates a profile successfully", async () => {
+    const regeneratedProfile = {
+      id: 42,
+      status: "success",
+      rainfall_mm: 1500,
+      temperature_celsius: 24,
+      elevation_m: 300,
+      ph: 6.5,
+      slope: 4.5,
+      soil_texture: "clay",
+    };
+
+    fetchMock.mockResolvedValue(createResponse(true, 200, regeneratedProfile));
+
+    const { result } = renderHook(() => useProfileActions());
+
+    let returnedProfile: unknown;
+
+    await act(async () => {
+      returnedProfile = await result.current.regenerateProfile(42);
+    });
+
+    expect(returnedProfile).toEqual(regeneratedProfile);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/profile/42/regenerate"),
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          Accept: "application/json",
+        },
+      })
+    );
+
+    expect(result.current.isRegenerating).toBe(false);
+    expect(result.current.actionError).toBeNull();
+    expect(result.current.actionMessage).toBe(
+      "Environmental profile regenerated successfully."
+    );
+  });
+
+  it("shows the regenerating state while the request is pending", async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>(resolve => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useProfileActions());
+
+    let pendingRequest: Promise<unknown>;
+
+    act(() => {
+      pendingRequest = result.current.regenerateProfile(42);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRegenerating).toBe(true);
+    });
+
+    await act(async () => {
+      resolveFetch?.(
+        createResponse(true, 200, {
+          id: 42,
+          status: "success",
+        })
+      );
+
+      await pendingRequest;
+    });
+
+    expect(result.current.isRegenerating).toBe(false);
+  });
+
+  it("uses the backend detail when regeneration fails", async () => {
+    fetchMock.mockResolvedValue(
+      createResponse(false, 403, {
+        detail: "The user does not have adequate permissions.",
+      })
+    );
+
+    const { result } = renderHook(() => useProfileActions());
+
+    await act(async () => {
+      await expect(result.current.regenerateProfile(42)).rejects.toThrow(
+        "The user does not have adequate permissions."
+      );
+    });
+
+    expect(result.current.actionError).toBe(
+      "The user does not have adequate permissions."
+    );
+    expect(result.current.actionMessage).toBeNull();
+    expect(result.current.isRegenerating).toBe(false);
+  });
+
+  it("uses the response status when the error response is not JSON", async () => {
+    fetchMock.mockResolvedValue(createResponse(false, 503, undefined, true));
+
+    const { result } = renderHook(() => useProfileActions());
+
+    await act(async () => {
+      await expect(result.current.regenerateProfile(42)).rejects.toThrow(
+        "Request failed (503)"
+      );
+    });
+
+    expect(result.current.actionError).toBe("Request failed (503)");
+  });
+
+  it("uses the fallback error for a non-Error rejection", async () => {
+    fetchMock.mockRejectedValue("network failure");
+
+    const { result } = renderHook(() => useProfileActions());
+
+    await act(async () => {
+      await expect(result.current.regenerateProfile(42)).rejects.toThrow(
+        "Failed to regenerate the environmental profile."
+      );
+    });
+
+    expect(result.current.actionError).toBe(
+      "Failed to regenerate the environmental profile."
+    );
+    expect(result.current.isRegenerating).toBe(false);
+  });
+
+  it("rejects regeneration when no access token exists", async () => {
+    mockGetAccessToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useProfileActions());
+
+    await act(async () => {
+      await expect(result.current.regenerateProfile(42)).rejects.toThrow(
+        "You must be logged in."
+      );
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.actionError).toBe("You must be logged in.");
+  });
+
+  it("clears success and error feedback", async () => {
+    fetchMock.mockResolvedValue(
+      createResponse(true, 200, {
+        id: 42,
+        status: "success",
+      })
+    );
+
+    const { result } = renderHook(() => useProfileActions());
+
+    await act(async () => {
+      await result.current.regenerateProfile(42);
+    });
+
+    expect(result.current.actionMessage).not.toBeNull();
+
+    act(() => {
+      result.current.clearActionFeedback();
+    });
+
+    expect(result.current.actionMessage).toBeNull();
+    expect(result.current.actionError).toBeNull();
+  });
+});

--- a/frontend/src/test/useSearchProfiles.coverage.test.ts
+++ b/frontend/src/test/useSearchProfiles.coverage.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSearchProfiles } from "@/hooks/useSearchProfiles";
+import type { Farm } from "@/hooks/useUserProfiles";
+
+const { mockGetAccessToken } = vi.hoisted(() => ({
+  mockGetAccessToken: vi.fn(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+const fetchMock = vi.fn();
+
+function createResponse(
+  ok: boolean,
+  status: number,
+  body?: unknown,
+  rejectJson = false
+): Response {
+  return {
+    ok,
+    status,
+    json: rejectJson
+      ? vi.fn().mockRejectedValue(new Error("Invalid JSON"))
+      : vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function createFarm(id: number, rainfall = 800): Farm {
+  return {
+    id,
+    rainfall_mm: rainfall,
+    temperature_celsius: 22,
+    elevation_m: 150,
+    ph: 6.5,
+    soil_texture: { name: "Loam" },
+    area_ha: 12.345,
+    latitude: -37.12345,
+    longitude: 144.12345,
+    coastal: true,
+    riparian: false,
+    nitrogen_fixing: true,
+    shade_tolerant: false,
+    bank_stabilising: false,
+    slope: 3.75,
+    agroforestry_type: [],
+  } as Farm;
+}
+
+describe("useSearchProfiles additional coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue("test-token");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the API detail when loading a profile fails", async () => {
+    fetchMock.mockResolvedValue(
+      createResponse(false, 404, {
+        detail: "Farm profile was not found.",
+      })
+    );
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Farm profile was not found.");
+    });
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("uses a fallback message when the error is not JSON", async () => {
+    fetchMock.mockResolvedValue(createResponse(false, 500, undefined, true));
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Failed to load profile (500)");
+    });
+
+    expect(result.current.profile).toBeNull();
+  });
+
+  it("adds the queried farm ID when the response does not contain one", async () => {
+    const responseFarm = createFarm(42);
+    const farmWithoutId = { ...responseFarm } as Partial<Farm>;
+    delete farmWithoutId.id;
+
+    fetchMock.mockResolvedValue(createResponse(true, 200, farmWithoutId));
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.profile?.id).toBe(42);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/farms/42"),
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer test-token",
+          Accept: "application/json",
+        },
+      })
+    );
+  });
+
+  it("refetches the current profile", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createResponse(true, 200, createFarm(42, 800)))
+      .mockResolvedValueOnce(createResponse(true, 200, createFarm(42, 1200)));
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.profile?.rainfall_mm).toBe(800);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.profile?.rainfall_mm).toBe(1200);
+  });
+
+  it("replaces the currently displayed profile", () => {
+    const replacement = createFarm(42, 1600);
+
+    const { result } = renderHook(() => useSearchProfiles(""));
+
+    act(() => {
+      result.current.replaceProfile(replacement);
+    });
+
+    expect(result.current.profile).toEqual(replacement);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears the profile when there is no access token", async () => {
+    mockGetAccessToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useSearchProfiles("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
Implements profile editing and regeneration actions for authorised users on the Environmental Profile page.

- Reuses the existing Farm Edit modal for editing profile-related farm data.
- Adds an Edit action for Admin and Supervisor users.
- Adds a Regenerate action to rerun the environmental profile pipeline.
- Adds role and ownership checks for regeneration.
- Invalidates cached profile, sapling and recommendation data after updates.
- Adds loading, success and error feedback.
- Adds frontend and backend tests for the new behaviour.


## Related Issue / Task
Closes #194 #385 


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
The existing Farm Management edit form is reused to avoid duplicate forms and validation logic. The Regenerate action is restricted to authorised roles and includes rate limiting and cache invalidation.
