### PR TITLE
US-056: Add scoring parameters admin UI

### DIFF
--- a/backend/src/services/parameters.py
+++ b/backend/src/services/parameters.py
@@ -7,7 +7,7 @@ from src.schemas.parameters import ParameterCreate, ParameterUpdate
 
 
 async def get_all_parameters(db: AsyncSession) -> list[Parameter]:
-    result = await db.execute(select(Parameter).order_by(Parameter.species_id, Parameter.id))
+    result = await db.execute(select(Parameter).join(Species, Parameter.species_id == Species.id).order_by(Species.name, Parameter.id))
     return list(result.scalars().all())
 
 

--- a/backend/tests/test_recommendation_pipeline_integration.py
+++ b/backend/tests/test_recommendation_pipeline_integration.py
@@ -51,11 +51,7 @@ _SPECIES_IN_RANGE = {
 
 async def _load_farm_with_relationships(db: AsyncSession, farm_id: int) -> Farm:
     """Load a farm with the relationships required by SuitabilityFarm.from_db_model."""
-    result = await db.execute(
-        select(Farm)
-        .options(selectinload(Farm.soil_texture), selectinload(Farm.agroforestry_type))
-        .where(Farm.id == farm_id)
-    )
+    result = await db.execute(select(Farm).options(selectinload(Farm.soil_texture), selectinload(Farm.agroforestry_type)).where(Farm.id == farm_id))
     return result.scalar_one()
 
 
@@ -89,9 +85,7 @@ async def test_pipeline_returns_one_result_per_farm(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
     assert len(results) == 1
 
@@ -110,9 +104,7 @@ async def test_pipeline_result_contains_required_keys(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
     result = results[0]
     assert result["farm_id"] == farm.id
@@ -135,9 +127,7 @@ async def test_pipeline_recommendation_fields_and_types(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
     recommendations = results[0]["recommendations"]
     assert len(recommendations) > 0
@@ -167,9 +157,7 @@ async def test_pipeline_farm_id_matches_input(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
     assert results[0]["farm_id"] == farm.id
 
@@ -190,9 +178,7 @@ async def test_pipeline_with_no_species_returns_empty_recommendations(
     farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], [], cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], [], cfg)
 
     assert results[0]["recommendations"] == []
     assert results[0]["excluded_species"] == []
@@ -212,13 +198,9 @@ async def test_pipeline_persists_recommendations_to_database(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
-    saved = await async_session.execute(
-        select(Recommendation).where(Recommendation.farm_id == farm.id)
-    )
+    saved = await async_session.execute(select(Recommendation).where(Recommendation.farm_id == farm.id))
     records = saved.scalars().all()
     assert len(records) > 0
 
@@ -237,18 +219,12 @@ async def test_pipeline_replaces_existing_recommendations_on_rerun(
     cfg = get_recommend_config()
 
     farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
-    await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
     farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
-    await recommendation_service.run_recommendation_pipeline(
-        async_session, [farm_with_rels], all_species, cfg
-    )
+    await recommendation_service.run_recommendation_pipeline(async_session, [farm_with_rels], all_species, cfg)
 
-    saved = await async_session.execute(
-        select(Recommendation).where(Recommendation.farm_id == farm.id)
-    )
+    saved = await async_session.execute(select(Recommendation).where(Recommendation.farm_id == farm.id))
     records = saved.scalars().all()
     species_ids = [r.species_id for r in records]
     assert len(species_ids) == len(set(species_ids)), "No duplicate recommendations per farm after rerun"
@@ -272,9 +248,7 @@ async def test_pipeline_batch_returns_result_per_farm(
     all_species = await get_all_species_for_engine(async_session)
     cfg = get_recommend_config()
 
-    results = await recommendation_service.run_recommendation_pipeline(
-        async_session, farms, all_species, cfg
-    )
+    results = await recommendation_service.run_recommendation_pipeline(async_session, farms, all_species, cfg)
 
     assert len(results) == 2
     result_farm_ids = {r["farm_id"] for r in results}

--- a/backend/tests/test_recommendation_pipeline_integration.py
+++ b/backend/tests/test_recommendation_pipeline_integration.py
@@ -1,0 +1,282 @@
+"""Integration tests for the Backend → Data Science recommendation pipeline (US-065)."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.models.farm import Farm
+from src.models.recommendations import Recommendation
+from src.models.soil_texture import SoilTexture
+from src.models.species import Species
+from src.models.user import User
+from src.services import recommendation as recommendation_service
+from src.services.species import get_all_species_for_engine, get_recommend_config
+
+_FARM_PROFILE = {
+    "rainfall_mm": 1500,
+    "temperature_celsius": 22,
+    "elevation_m": 500,
+    "ph": 6.5,
+    "soil_texture_id": 1,
+    "area_ha": 5.0,
+    "latitude": -8.5,
+    "longitude": 126.5,
+    "coastal": False,
+    "riparian": False,
+    "nitrogen_fixing": False,
+    "shade_tolerant": False,
+    "bank_stabilising": False,
+    "slope": 10.0,
+}
+
+_SPECIES_IN_RANGE = {
+    "name": "Tectona grandis",
+    "common_name": "Teak",
+    "rainfall_mm_min": 1000,
+    "rainfall_mm_max": 2000,
+    "temperature_celsius_min": 18,
+    "temperature_celsius_max": 30,
+    "elevation_m_min": 0,
+    "elevation_m_max": 1000,
+    "ph_min": 5.0,
+    "ph_max": 8.0,
+    "coastal": False,
+    "riparian": False,
+    "nitrogen_fixing": False,
+    "shade_tolerant": False,
+    "bank_stabilising": False,
+}
+
+
+async def _load_farm_with_relationships(db: AsyncSession, farm_id: int) -> Farm:
+    """Load a farm with the relationships required by SuitabilityFarm.from_db_model."""
+    result = await db.execute(
+        select(Farm)
+        .options(selectinload(Farm.soil_texture), selectinload(Farm.agroforestry_type))
+        .where(Farm.id == farm_id)
+    )
+    return result.scalar_one()
+
+
+@pytest.fixture
+async def pipeline_species(async_session: AsyncSession, setup_soil_texture):
+    """Seeds a species compatible with _FARM_PROFILE, associated with soil texture id=1."""
+    result = await async_session.execute(select(SoilTexture).where(SoilTexture.id == 1))
+    loam = result.scalar_one()
+
+    species = Species(**_SPECIES_IN_RANGE)
+    species.soil_textures = [loam]
+    async_session.add(species)
+    await async_session.flush()
+    return species
+
+
+# ---- Output structure tests ----
+
+
+async def test_pipeline_returns_one_result_per_farm(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Pipeline returns exactly one result dict per farm passed in."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    assert len(results) == 1
+
+
+async def test_pipeline_result_contains_required_keys(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Each pipeline result contains farm_id, timestamp_utc, recommendations, and excluded_species."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    result = results[0]
+    assert result["farm_id"] == farm.id
+    assert "timestamp_utc" in result
+    assert "recommendations" in result
+    assert "excluded_species" in result
+
+
+async def test_pipeline_recommendation_fields_and_types(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Each recommendation entry has the required fields with correct types."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    recommendations = results[0]["recommendations"]
+    assert len(recommendations) > 0
+
+    for rec in recommendations:
+        assert "species_id" in rec
+        assert "rank_overall" in rec
+        assert "score_mcda" in rec
+        assert "key_reasons" in rec
+        assert isinstance(rec["species_id"], int)
+        assert isinstance(rec["rank_overall"], int)
+        assert isinstance(rec["score_mcda"], float)
+        assert isinstance(rec["key_reasons"], list)
+
+
+async def test_pipeline_farm_id_matches_input(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """The farm_id in each result matches the corresponding input farm."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    assert results[0]["farm_id"] == farm.id
+
+
+# ---- Behaviour tests ----
+
+
+async def test_pipeline_with_no_species_returns_empty_recommendations(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    setup_soil_texture,
+):
+    """Pipeline returns empty recommendations and excluded_species when given an empty species list."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], [], cfg
+    )
+
+    assert results[0]["recommendations"] == []
+    assert results[0]["excluded_species"] == []
+
+
+async def test_pipeline_persists_recommendations_to_database(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Pipeline writes Recommendation records to the database after running."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    saved = await async_session.execute(
+        select(Recommendation).where(Recommendation.farm_id == farm.id)
+    )
+    records = saved.scalars().all()
+    assert len(records) > 0
+
+
+async def test_pipeline_replaces_existing_recommendations_on_rerun(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Running the pipeline twice for the same farm replaces old recommendations without duplicating them."""
+    farm = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add(farm)
+    await async_session.flush()
+
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    farm_with_rels = await _load_farm_with_relationships(async_session, farm.id)
+    await recommendation_service.run_recommendation_pipeline(
+        async_session, [farm_with_rels], all_species, cfg
+    )
+
+    saved = await async_session.execute(
+        select(Recommendation).where(Recommendation.farm_id == farm.id)
+    )
+    records = saved.scalars().all()
+    species_ids = [r.species_id for r in records]
+    assert len(species_ids) == len(set(species_ids)), "No duplicate recommendations per farm after rerun"
+
+
+async def test_pipeline_batch_returns_result_per_farm(
+    async_session: AsyncSession,
+    test_officer_user: User,
+    pipeline_species: Species,
+):
+    """Pipeline processes multiple farms in a batch and returns one result per farm."""
+    farm1 = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    farm2 = Farm(**_FARM_PROFILE, user_id=test_officer_user.id)
+    async_session.add_all([farm1, farm2])
+    await async_session.flush()
+
+    farms = [
+        await _load_farm_with_relationships(async_session, farm1.id),
+        await _load_farm_with_relationships(async_session, farm2.id),
+    ]
+    all_species = await get_all_species_for_engine(async_session)
+    cfg = get_recommend_config()
+
+    results = await recommendation_service.run_recommendation_pipeline(
+        async_session, farms, all_species, cfg
+    )
+
+    assert len(results) == 2
+    result_farm_ids = {r["farm_id"] for r in results}
+    assert farm1.id in result_farm_ids
+    assert farm2.id in result_farm_ids

--- a/frontend/src/pages/admin/settings/ScoringParametersPage.tsx
+++ b/frontend/src/pages/admin/settings/ScoringParametersPage.tsx
@@ -1,13 +1,494 @@
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 
+import { useAuth } from "../../../contexts/AuthContext";
+import { getAllSpecies, Species } from "../../../utils/speciesApi";
+import {
+  createParameter,
+  deleteParameter,
+  getAllParameters,
+  Parameter,
+  ParameterPayload,
+  updateParameter,
+} from "../../../utils/parametersApi";
+
+type ModalMode = "create" | "edit" | null;
+
+const emptyForm: ParameterPayload = {
+  species_id: 0,
+  feature: "",
+  score_method: "",
+  weight: 0,
+  trap_left_tol: null,
+  trap_right_tol: null,
+};
+
+const SCORE_METHODS = [
+  "cat_compatibility",
+  "cat_exact",
+  "num_range",
+  "trapezoid",
+] as const;
+
+const FEATURES = [
+  "elevation_m",
+  "ph",
+  "rainfall_mm",
+  "soil_texture",
+  "temperature_celsius",
+] as const;
+
+function buildParameterPayload(param: Parameter): ParameterPayload {
+  return {
+    species_id: param.species_id,
+    feature: param.feature,
+    score_method: param.score_method ?? "",
+    weight: param.weight ?? 0,
+    trap_left_tol: param.trap_left_tol,
+    trap_right_tol: param.trap_right_tol,
+  };
+}
+
 function ScoringParametersPage() {
+  const { getAccessToken } = useAuth();
+
+  const [parameters, setParameters] = useState<Parameter[]>([]);
+  const [species, setSpecies] = useState<Species[]>([]);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const [modalMode, setModalMode] = useState<ModalMode>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [formData, setFormData] = useState<ParameterPayload>(emptyForm);
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const token = getAccessToken();
+
+      if (!token) {
+        setError("You must be logged in as admin to view scoring parameters.");
+        return;
+      }
+
+      const [paramData, speciesData] = await Promise.all([
+        getAllParameters(token),
+        getAllSpecies(token),
+      ]);
+
+      setParameters(paramData);
+      setSpecies([...speciesData].sort((a, b) => a.name.localeCompare(b.name)));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load scoring parameters"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken]);
+
+  function getSpeciesName(speciesId: number): string {
+    const found = species.find(s => s.id === speciesId);
+    return found ? found.name : `Species ${speciesId}`;
+  }
+
+  function openCreateModal() {
+    setError(null);
+    setSuccessMessage(null);
+    setEditingId(null);
+    setFormData(emptyForm);
+    setModalMode("create");
+    setFormError(null);
+  }
+
+  function openEditModal(param: Parameter) {
+    setError(null);
+    setSuccessMessage(null);
+    setEditingId(param.id);
+    setFormData(buildParameterPayload(param));
+    setModalMode("edit");
+    setFormError(null);
+  }
+
+  function closeModal() {
+    setFormError(null);
+    setError(null);
+    setSaving(false);
+    setModalMode(null);
+    setEditingId(null);
+    setFormData(emptyForm);
+  }
+
+  function updateFormField<K extends keyof ParameterPayload>(
+    field: K,
+    value: ParameterPayload[K]
+  ) {
+    setFormData(current => ({
+      ...current,
+      [field]: value,
+    }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const token = getAccessToken();
+
+    if (!token) {
+      setError("You must be logged in as admin to manage scoring parameters.");
+      return;
+    }
+
+    if (formData.species_id === 0) {
+      setFormError("Please select a species.");
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setError(null);
+      setSuccessMessage(null);
+
+      if (modalMode === "create") {
+        await createParameter(formData, token);
+        setSuccessMessage("Scoring parameter created successfully.");
+      }
+
+      if (modalMode === "edit" && editingId !== null) {
+        const updatePayload = {
+          species_id: formData.species_id,
+          feature: formData.feature,
+          score_method: formData.score_method,
+          trap_left_tol: formData.trap_left_tol,
+          trap_right_tol: formData.trap_right_tol,
+        };
+        await updateParameter(editingId, updatePayload, token);
+        setSuccessMessage("Scoring parameter updated successfully.");
+      }
+
+      closeModal();
+      await loadData();
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Failed to save scoring parameter.";
+      setFormError(message);
+      setError(null);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    const token = getAccessToken();
+
+    if (!token) {
+      setError("You must be logged in as admin to delete scoring parameters.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "Are you sure you want to delete this scoring parameter?"
+    );
+
+    if (!confirmed) return;
+
+    try {
+      setError(null);
+      setSuccessMessage(null);
+      await deleteParameter(id, token);
+      setSuccessMessage("Scoring parameter deleted successfully.");
+      await loadData();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to delete scoring parameter"
+      );
+    }
+  }
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
   return (
     <>
       <Helmet>
-        <title>Scoring Parameters | Planting Optimisation Tool</title>
+        <title>Admin | Scoring Parameters</title>
       </Helmet>
-      <h2>Scoring Parameters</h2>
-      <p>UI for managing scoring parameters is currently not implemented</p>
+
+      <nav className="admin-back-nav">
+        <Link to="/admin/settings/weighting" className="admin-back-link">
+          &larr; Back to Weighting Hub
+        </Link>
+      </nav>
+
+      <section className="admin-page-card">
+        <div className="admin-parameters-header">
+          <div>
+            <h2>Scoring Parameters</h2>
+            <p>
+              Manage the scoring parameters used by the recommendation model for
+              each species.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={openCreateModal}
+          >
+            Add Parameter
+          </button>
+        </div>
+
+        {loading && <p>Loading scoring parameters...</p>}
+
+        {error && <p className="admin-error-message">{error}</p>}
+
+        {successMessage && (
+          <p className="admin-success-message">{successMessage}</p>
+        )}
+
+        {!loading && !error && parameters.length === 0 && (
+          <p>No scoring parameters found.</p>
+        )}
+
+        {!loading && parameters.length > 0 && (
+          <div className="admin-table-wrapper">
+            <table className="admin-parameters-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Species</th>
+                  <th>Feature</th>
+                  <th>Score Method</th>
+                  <th>Weight</th>
+                  <th>Trap Left Tol</th>
+                  <th>Trap Right Tol</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {parameters.map(param => (
+                  <tr key={param.id}>
+                    <td>{param.id}</td>
+                    <td>{getSpeciesName(param.species_id)}</td>
+                    <td>{param.feature}</td>
+                    <td>{param.score_method ?? "—"}</td>
+                    <td>
+                      {param.weight != null
+                        ? Number(param.weight.toFixed(4))
+                        : "—"}
+                    </td>
+                    <td>{param.trap_left_tol ?? "—"}</td>
+                    <td>{param.trap_right_tol ?? "—"}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="admin-action-btn"
+                        onClick={() => openEditModal(param)}
+                      >
+                        Edit
+                      </button>
+
+                      <button
+                        type="button"
+                        className="admin-action-btn admin-action-danger"
+                        onClick={() => void handleDelete(param.id)}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {modalMode && (
+        <div className="admin-modal-backdrop">
+          <div
+            className="admin-parameters-modal"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="admin-modal-header">
+              <div>
+                <h3>
+                  {modalMode === "create"
+                    ? "Add Scoring Parameter"
+                    : "Edit Scoring Parameter"}
+                </h3>
+                <p>
+                  Configure a scoring parameter for the recommendation model.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                className="admin-modal-close"
+                onClick={closeModal}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+
+            <form className="admin-parameters-form" onSubmit={handleSubmit}>
+              {formError && (
+                <div className="admin-error-message" role="alert">
+                  {formError}
+                </div>
+              )}
+
+              <div className="admin-form-section">
+                <h4>Species and Feature</h4>
+
+                <label>
+                  Species
+                  <select
+                    required
+                    value={formData.species_id}
+                    onChange={event =>
+                      updateFormField("species_id", Number(event.target.value))
+                    }
+                  >
+                    <option value={0} disabled>
+                      Select a species
+                    </option>
+                    {species.map(s => (
+                      <option key={s.id} value={s.id}>
+                        {s.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label>
+                  Feature
+                  <select
+                    required
+                    value={formData.feature}
+                    onChange={event =>
+                      updateFormField("feature", event.target.value)
+                    }
+                  >
+                    <option value="" disabled>
+                      Select a feature
+                    </option>
+                    {FEATURES.map(feature => (
+                      <option key={feature} value={feature}>
+                        {feature}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <div className="admin-form-section">
+                <h4>Scoring Configuration</h4>
+
+                <div className="admin-form-grid">
+                  <label>
+                    Score Method
+                    <select
+                      required
+                      value={formData.score_method}
+                      onChange={event => {
+                        updateFormField("score_method", event.target.value);
+                        if (event.target.value !== "trapezoid") {
+                          updateFormField("trap_left_tol", null);
+                          updateFormField("trap_right_tol", null);
+                        }
+                      }}
+                    >
+                      <option value="" disabled>
+                        Select a method
+                      </option>
+                      {SCORE_METHODS.map(method => (
+                        <option key={method} value={method}>
+                          {method}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  {formData.score_method === "trapezoid" && (
+                    <label>
+                      Trap Left Tolerance
+                      <input
+                        type="number"
+                        step="1"
+                        min="0"
+                        max="5000"
+                        placeholder="Optional"
+                        value={formData.trap_left_tol ?? ""}
+                        onChange={event =>
+                          updateFormField(
+                            "trap_left_tol",
+                            event.target.value === ""
+                              ? null
+                              : Number(event.target.value)
+                          )
+                        }
+                      />
+                    </label>
+                  )}
+
+                  {formData.score_method === "trapezoid" && (
+                    <label>
+                      Trap Right Tolerance
+                      <input
+                        type="number"
+                        step="1"
+                        min="0"
+                        max="5000"
+                        placeholder="Optional"
+                        value={formData.trap_right_tol ?? ""}
+                        onChange={event =>
+                          updateFormField(
+                            "trap_right_tol",
+                            event.target.value === ""
+                              ? null
+                              : Number(event.target.value)
+                          )
+                        }
+                      />
+                    </label>
+                  )}
+                </div>
+              </div>
+
+              <div className="admin-modal-actions">
+                <button
+                  type="button"
+                  className="admin-action-btn"
+                  onClick={closeModal}
+                >
+                  Cancel
+                </button>
+
+                <button type="submit" className="btn-primary" disabled={saving}>
+                  {saving ? "Saving..." : "Save Parameter"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1842,3 +1842,73 @@ main.container {
   margin: 12px 0;
   padding: 12px 14px;
 }
+
+/* =========================
+   SCORING PARAMETERS PAGE
+   ========================= */
+
+.admin-parameters-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.admin-parameters-header p {
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+.admin-parameters-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.admin-parameters-table th,
+.admin-parameters-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 12px 10px;
+  text-align: left;
+}
+
+.admin-parameters-table th {
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.admin-parameters-table tbody tr:hover {
+  background: var(--surface);
+}
+
+.admin-parameters-table td {
+  vertical-align: middle;
+}
+
+.admin-parameters-modal {
+  background: var(--bg);
+  border-radius: 5px;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.28);
+  display: flex;
+  flex-direction: column;
+  max-height: 88vh;
+  max-width: 720px;
+  overflow: hidden;
+  padding: 24px 24px 0;
+  width: 100%;
+}
+
+.admin-parameters-form {
+  display: grid;
+  gap: 18px;
+  overflow-y: auto;
+  padding: 0 4px 24px;
+}
+
+.admin-parameters-form select {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 1rem;
+  padding: 10px 12px;
+  width: 100%;
+}

--- a/frontend/src/test/scoringParametersPage.test.tsx
+++ b/frontend/src/test/scoringParametersPage.test.tsx
@@ -24,9 +24,12 @@ vi.mock("../utils/speciesApi", () => ({
   getAllSpecies: vi.fn(),
 }));
 
-vi.mock("../contexts/AuthContext", () => ({
-  useAuth: () => ({ getAccessToken: () => "test-token" }),
-}));
+vi.mock("../contexts/AuthContext", () => {
+  const getAccessToken = () => "test-token";
+  return {
+    useAuth: () => ({ getAccessToken }),
+  };
+});
 
 const mockSpecies = [
   {
@@ -374,5 +377,108 @@ describe("ScoringParametersPage", () => {
     expect(
       screen.queryByLabelText(/trap right tolerance/i)
     ).not.toBeInTheDocument();
+  });
+
+  it("shows error when delete fails", async () => {
+    vi.mocked(deleteParameter).mockRejectedValue(new Error("Delete failed"));
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    await user.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete failed")).toBeInTheDocument();
+    });
+  });
+
+  it("shows validation error when no species is selected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+
+    await user.selectOptions(
+      screen.getByLabelText(/^feature$/i),
+      "elevation_m"
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "num_range"
+    );
+
+    await user.click(screen.getByRole("button", { name: /save parameter/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Please select a species."
+      );
+    });
+  });
+
+  it("clears tolerance values to null when inputs are cleared", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "trapezoid"
+    );
+
+    const trapLeft = screen.getByLabelText(/trap left tolerance/i);
+    const trapRight = screen.getByLabelText(/trap right tolerance/i);
+
+    await user.type(trapLeft, "100");
+    await user.type(trapRight, "200");
+
+    expect(trapLeft).toHaveValue(100);
+    expect(trapRight).toHaveValue(200);
+
+    await user.clear(trapLeft);
+    await user.clear(trapRight);
+
+    expect(trapLeft).toHaveValue(null);
+    expect(trapRight).toHaveValue(null);
+  });
+
+  it("displays dash for null weight in the table", async () => {
+    vi.mocked(getAllParameters).mockResolvedValue([
+      { ...mockParameters[0], weight: null },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows fallback name when species is not found", async () => {
+    vi.mocked(getAllParameters).mockResolvedValue([
+      { ...mockParameters[0], species_id: 999 },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Species 999")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/test/scoringParametersPage.test.tsx
+++ b/frontend/src/test/scoringParametersPage.test.tsx
@@ -1,23 +1,378 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import ScoringParametersPage from "@/pages/admin/settings/ScoringParametersPage";
+import {
+  createParameter,
+  deleteParameter,
+  getAllParameters,
+  updateParameter,
+} from "../utils/parametersApi";
+import { getAllSpecies } from "../utils/speciesApi";
 
-test("renders scoring parameters placeholder", () => {
-  render(
-    <HelmetProvider>
-      <ScoringParametersPage />
-    </HelmetProvider>
+vi.mock("../utils/parametersApi", () => ({
+  getAllParameters: vi.fn(),
+  createParameter: vi.fn(),
+  updateParameter: vi.fn(),
+  deleteParameter: vi.fn(),
+}));
+
+vi.mock("../utils/speciesApi", () => ({
+  getAllSpecies: vi.fn(),
+}));
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({ getAccessToken: () => "test-token" }),
+}));
+
+const mockSpecies = [
+  {
+    id: 1,
+    name: "Tectona grandis",
+    common_name: "Teak",
+    rainfall_mm_min: 1000,
+    rainfall_mm_max: 2000,
+    temperature_celsius_min: 20,
+    temperature_celsius_max: 35,
+    elevation_m_min: 0,
+    elevation_m_max: 800,
+    ph_min: 6.0,
+    ph_max: 8.0,
+    coastal: false,
+    riparian: false,
+    nitrogen_fixing: false,
+    shade_tolerant: false,
+    bank_stabilising: false,
+    soil_textures: [],
+    agroforestry_types: [],
+  },
+];
+
+const mockParameters = [
+  {
+    id: 1,
+    species_id: 1,
+    feature: "rainfall_mm",
+    score_method: "trapezoid",
+    weight: 0.4,
+    trap_left_tol: 100,
+    trap_right_tol: 200,
+  },
+  {
+    id: 2,
+    species_id: 1,
+    feature: "temperature_celsius",
+    score_method: "trapezoid",
+    weight: 0.3,
+    trap_left_tol: null,
+    trap_right_tol: null,
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <HelmetProvider>
+        <ScoringParametersPage />
+      </HelmetProvider>
+    </MemoryRouter>
   );
+}
 
-  // Check for the main heading[
-  expect(
-    screen.getByRole("heading", { name: /Scoring Parameters/i })
-  ).toBeInTheDocument();
+describe("ScoringParametersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAllParameters).mockResolvedValue(mockParameters);
+    vi.mocked(getAllSpecies).mockResolvedValue(mockSpecies);
+  });
 
-  // Check for the placeholder text
-  expect(
-    screen.getByText(
-      /UI for managing scoring parameters is currently not implemented/i
-    )
-  ).toBeInTheDocument();
+  it("loads and displays scoring parameters", async () => {
+    renderPage();
+
+    expect(
+      screen.getByText("Loading scoring parameters...")
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("temperature_celsius")).toBeInTheDocument();
+    expect(screen.getAllByText("Tectona grandis")).toHaveLength(2);
+    expect(screen.getAllByText("trapezoid")).toHaveLength(2);
+  });
+
+  it("shows error when load fails", async () => {
+    vi.mocked(getAllParameters).mockRejectedValue(new Error("Network error"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+
+  it("opens create modal when Add Parameter is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+
+    expect(screen.getByRole("dialog", { name: "" })).toBeInTheDocument();
+    expect(screen.getByText("Add Scoring Parameter")).toBeInTheDocument();
+  });
+
+  it("creates a parameter successfully", async () => {
+    vi.mocked(createParameter).mockResolvedValue({
+      id: 3,
+      species_id: 1,
+      feature: "elevation",
+      score_method: "trapezoid",
+      weight: 0.3,
+      trap_left_tol: null,
+      trap_right_tol: null,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+
+    await user.selectOptions(screen.getByLabelText(/^species$/i), "1");
+    await user.selectOptions(
+      screen.getByLabelText(/^feature$/i),
+      "elevation_m"
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "trapezoid"
+    );
+
+    await user.click(screen.getByRole("button", { name: /save parameter/i }));
+
+    await waitFor(() => {
+      expect(createParameter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          species_id: 1,
+          feature: "elevation_m",
+          score_method: "trapezoid",
+          weight: 0,
+        }),
+        "test-token"
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Scoring parameter created successfully.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("opens edit modal with prefilled data", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    await user.click(editButtons[0]);
+
+    expect(screen.getByText("Edit Scoring Parameter")).toBeInTheDocument();
+
+    const featureSelect = screen.getByLabelText(/^feature$/i);
+    expect(featureSelect).toHaveValue("rainfall_mm");
+  });
+
+  it("updates a parameter successfully", async () => {
+    vi.mocked(updateParameter).mockResolvedValue({
+      ...mockParameters[0],
+      feature: "rainfall_updated",
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    await user.click(editButtons[0]);
+
+    await user.selectOptions(
+      screen.getByLabelText(/^feature$/i),
+      "elevation_m"
+    );
+
+    await user.click(screen.getByRole("button", { name: /save parameter/i }));
+
+    await waitFor(() => {
+      expect(updateParameter).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ feature: "elevation_m" }),
+        "test-token"
+      );
+      const updateCall = vi.mocked(updateParameter).mock.calls[0][1];
+      expect(updateCall).not.toHaveProperty("weight");
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Scoring parameter updated successfully.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("deletes a parameter after confirmation", async () => {
+    vi.mocked(deleteParameter).mockResolvedValue(undefined);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    await user.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(deleteParameter).toHaveBeenCalledWith(1, "test-token");
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Scoring parameter deleted successfully.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not delete when confirmation is cancelled", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    await user.click(deleteButtons[0]);
+
+    expect(deleteParameter).not.toHaveBeenCalled();
+  });
+
+  it("shows form error in modal and keeps modal open", async () => {
+    vi.mocked(createParameter).mockRejectedValue(
+      new Error("Species not found")
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+
+    await user.selectOptions(screen.getByLabelText(/^species$/i), "1");
+    await user.selectOptions(
+      screen.getByLabelText(/^feature$/i),
+      "elevation_m"
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "trapezoid"
+    );
+
+    await user.click(screen.getByRole("button", { name: /save parameter/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Species not found");
+    });
+
+    expect(screen.getByText("Add Scoring Parameter")).toBeInTheDocument();
+  });
+
+  it("closes modal when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+    expect(screen.getByText("Add Scoring Parameter")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText("Add Scoring Parameter")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no parameters exist", async () => {
+    vi.mocked(getAllParameters).mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No scoring parameters found.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows tolerance fields only when score method is trapezoid", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("rainfall_mm")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add parameter/i }));
+
+    expect(
+      screen.queryByLabelText(/trap left tolerance/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/trap right tolerance/i)
+    ).not.toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "trapezoid"
+    );
+
+    expect(screen.getByLabelText(/trap left tolerance/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/trap right tolerance/i)).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByLabelText(/score method/i),
+      "num_range"
+    );
+
+    expect(
+      screen.queryByLabelText(/trap left tolerance/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/trap right tolerance/i)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/utils/parametersApi.ts
+++ b/frontend/src/utils/parametersApi.ts
@@ -1,0 +1,150 @@
+const API_BASE = import.meta.env.VITE_API_URL;
+
+// ---------- TYPES ----------
+
+export interface Parameter {
+  id: number;
+  species_id: number;
+  feature: string;
+  score_method: string | null;
+  weight: number | null;
+  trap_left_tol: number | null;
+  trap_right_tol: number | null;
+}
+
+export interface ParameterPayload {
+  species_id: number;
+  feature: string;
+  score_method: string;
+  weight: number;
+  trap_left_tol: number | null;
+  trap_right_tol: number | null;
+}
+
+export interface ParameterUpdatePayload {
+  species_id?: number;
+  feature?: string;
+  score_method?: string;
+  weight?: number;
+  trap_left_tol?: number | null;
+  trap_right_tol?: number | null;
+}
+
+// ---------- HELPERS ----------
+
+async function handleResponse(res: Response) {
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(formatApiError(error));
+  }
+  return res.json();
+}
+
+function formatApiError(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "detail" in error &&
+    Array.isArray(error.detail)
+  ) {
+    return error.detail
+      .map((item: unknown) => {
+        if (typeof item === "object" && item !== null) {
+          if ("msg" in item && typeof item.msg === "string") {
+            return item.msg;
+          }
+          if ("message" in item && typeof item.message === "string") {
+            return item.message;
+          }
+        }
+        return "Invalid parameter data.";
+      })
+      .join(" ");
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "detail" in error &&
+    typeof error.detail === "string"
+  ) {
+    return error.detail;
+  }
+
+  return "API error";
+}
+
+// ---------- PARAMETERS ----------
+
+export async function getAllParameters(token: string): Promise<Parameter[]> {
+  const res = await fetch(`${API_BASE}/parameters`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return handleResponse(res);
+}
+
+export async function getParametersBySpecies(
+  speciesId: number,
+  token: string
+): Promise<Parameter[]> {
+  const res = await fetch(`${API_BASE}/parameters/species/${speciesId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return handleResponse(res);
+}
+
+export async function createParameter(
+  data: ParameterPayload,
+  token: string
+): Promise<Parameter> {
+  const res = await fetch(`${API_BASE}/parameters`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+
+  return handleResponse(res);
+}
+
+export async function updateParameter(
+  id: number,
+  data: ParameterUpdatePayload,
+  token: string
+): Promise<Parameter> {
+  const res = await fetch(`${API_BASE}/parameters/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+
+  return handleResponse(res);
+}
+
+export async function deleteParameter(
+  id: number,
+  token: string
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/parameters/${id}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(formatApiError(error));
+  }
+}


### PR DESCRIPTION
## Description
Implements the scoring parameters admin page, completing the full-stack CRUD interface for the parameters table. The backend API was added in PR #461 (US-055). This PR adds the matching frontend so admins can view, create, edit, and delete scoring parameters without direct database access.

**What was built:**
- `frontend/src/utils/parametersApi.ts` - new API utility (modelled after `speciesApi.ts`) with typed interfaces and full CRUD functions
- `frontend/src/pages/admin/settings/ScoringParametersPage.tsx` - full admin page with data table, modal form, inline success/error messages, and delete confirmation
- `frontend/src/test/scoringParametersPage.test.tsx` - 12 tests replacing a placeholder file (see Testing section)
- `frontend/src/style.css` - CSS classes for the parameters page following project conventions
- `backend/src/services/parameters.py` - changed table sort from `species_id` (numeric, disorganised) to alphabetical by species name via a JOIN on the Species table

**Key decisions:**
- Feature and Score Method are dropdowns, not free text. Valid values are sourced directly from the scoring engine (`scoring.py`) and model config (`recommend.yaml`). Free text would allow admins to save values that cause a `ValueError` in the engine at runtime.
- Trap Left Tolerance and Trap Right Tolerance are conditionally shown. They only appear when Score Method is set to `trapezoid`. For other methods these fields have no effect on the scoring engine, so hiding them prevents confusing data entry.
- Weight is read-only in the table and excluded from the form entirely. Per the US-056 notes, weights are managed via the separate Weighting Hub UI. Weight defaults to 0 on create and is omitted from update payloads.
- The parameters table is now sorted alphabetically by species name. The previous sort was by `species_id` (a number), which made the table look disorganised. A JOIN on the `Species` table was added to the `get_all_parameters` service.
- The species dropdown in the form is sorted alphabetically on the frontend only, to avoid touching the shared species service.

**Testing** - Test types align with the project test strategy

17 tests covering:
- Render: page loads and displays parameters correctly
- State: loading state, API error state, empty state (no parameters found)
- Interaction: create, edit, delete (confirmed and cancelled), modal open/close, form error kept in modal on failure
- Conditional behaviour: tolerance fields appear only when score method is trapezoid, disappear when switched away

## Related Issue / Task
This PR is related to User Story #411 and closes following sub-tasks from that story.
Closes #411 
Closes #428 
Closes #429

## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [x] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
<!-- Any extra context, screenshots, or caveats for the reviewers -->
