### PR TITLE
US: Add admin CRUD APIs for exclusion rules and dependencies

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -19,6 +19,7 @@ from src.routers import (
     auth,
     batch_estimation,
     environmental_profile,
+    exclusion_rules,
     farm,
     global_weights,
     parameters,
@@ -80,6 +81,7 @@ app.include_router(farm.router)
 app.include_router(recommendation.router)
 app.include_router(soil_texture.router)
 app.include_router(environmental_profile.router)
+app.include_router(exclusion_rules.router)
 app.include_router(sapling_estimation.router)
 app.include_router(batch_estimation.router)
 app.include_router(ahp.router)

--- a/backend/src/routers/exclusion_rules.py
+++ b/backend/src/routers/exclusion_rules.py
@@ -1,0 +1,282 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.database import get_db_session
+from src.dependencies import get_user_id, limiter, require_role
+from src.schemas.exclusion_rules import (
+    SpeciesDependencyCreate,
+    SpeciesDependencyRead,
+    SpeciesDependencyUpdate,
+    SpeciesExclusionRuleCreate,
+    SpeciesExclusionRuleRead,
+    SpeciesExclusionRuleUpdate,
+)
+from src.schemas.user import Role, UserRead
+from src.services import exclusion_rules as exclusion_rules_service
+
+router = APIRouter()
+
+exclusion_rules_router = APIRouter(
+    prefix="/exclusion-rules",
+    tags=["Exclusion Rules"],
+)
+dependencies_router = APIRouter(
+    prefix="/species-dependencies",
+    tags=["Species Dependencies"],
+)
+
+
+@exclusion_rules_router.get(
+    "",
+    response_model=List[SpeciesExclusionRuleRead],
+)
+@limiter.limit("30/minute", key_func=get_user_id)
+async def list_exclusion_rules(
+    request: Request,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Return all species exclusion rules. Requires ADMIN role."""
+    return await exclusion_rules_service.get_all_exclusion_rules(db)
+
+
+@exclusion_rules_router.get(
+    "/{rule_id}",
+    response_model=SpeciesExclusionRuleRead,
+)
+@limiter.limit("30/minute", key_func=get_user_id)
+async def get_exclusion_rule(
+    request: Request,
+    rule_id: int,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Return one species exclusion rule by ID. Requires ADMIN role."""
+    rule = await exclusion_rules_service.get_exclusion_rule_by_id(
+        db,
+        rule_id,
+    )
+
+    if rule is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exclusion rule not found",
+        )
+
+    return rule
+
+
+@exclusion_rules_router.post(
+    "",
+    response_model=SpeciesExclusionRuleRead,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def create_exclusion_rule(
+    request: Request,
+    payload: SpeciesExclusionRuleCreate,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Create a species exclusion rule. Requires ADMIN role."""
+    try:
+        return await exclusion_rules_service.create_exclusion_rule(
+            db,
+            payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+
+@exclusion_rules_router.patch(
+    "/{rule_id}",
+    response_model=SpeciesExclusionRuleRead,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def update_exclusion_rule(
+    request: Request,
+    rule_id: int,
+    payload: SpeciesExclusionRuleUpdate,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Update a species exclusion rule. Requires ADMIN role."""
+    try:
+        rule = await exclusion_rules_service.update_exclusion_rule(
+            db,
+            rule_id,
+            payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+    if rule is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exclusion rule not found",
+        )
+
+    return rule
+
+
+@exclusion_rules_router.delete(
+    "/{rule_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def delete_exclusion_rule(
+    request: Request,
+    rule_id: int,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Delete a species exclusion rule. Requires ADMIN role."""
+    deleted = await exclusion_rules_service.delete_exclusion_rule(
+        db,
+        rule_id,
+    )
+
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exclusion rule not found",
+        )
+
+    return
+
+
+@dependencies_router.get(
+    "",
+    response_model=List[SpeciesDependencyRead],
+)
+@limiter.limit("30/minute", key_func=get_user_id)
+async def list_dependencies(
+    request: Request,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Return all species dependencies. Requires ADMIN role."""
+    return await exclusion_rules_service.get_all_dependencies(db)
+
+
+@dependencies_router.get(
+    "/{dependency_id}",
+    response_model=SpeciesDependencyRead,
+)
+@limiter.limit("30/minute", key_func=get_user_id)
+async def get_dependency(
+    request: Request,
+    dependency_id: int,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Return one species dependency by ID. Requires ADMIN role."""
+    dependency = await exclusion_rules_service.get_dependency_by_id(
+        db,
+        dependency_id,
+    )
+
+    if dependency is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Species dependency not found",
+        )
+
+    return dependency
+
+
+@dependencies_router.post(
+    "",
+    response_model=SpeciesDependencyRead,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def create_dependency(
+    request: Request,
+    payload: SpeciesDependencyCreate,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Create a species dependency. Requires ADMIN role."""
+    try:
+        return await exclusion_rules_service.create_dependency(
+            db,
+            payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+
+@dependencies_router.patch(
+    "/{dependency_id}",
+    response_model=SpeciesDependencyRead,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def update_dependency(
+    request: Request,
+    dependency_id: int,
+    payload: SpeciesDependencyUpdate,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Update a species dependency. Requires ADMIN role."""
+    try:
+        dependency = await exclusion_rules_service.update_dependency(
+            db,
+            dependency_id,
+            payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+    if dependency is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Species dependency not found",
+        )
+
+    return dependency
+
+
+@dependencies_router.delete(
+    "/{dependency_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+@limiter.limit("10/minute", key_func=get_user_id)
+async def delete_dependency(
+    request: Request,
+    dependency_id: int,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: UserRead = Depends(require_role(Role.ADMIN)),
+):
+    """Delete a species dependency. Requires ADMIN role."""
+    deleted = await exclusion_rules_service.delete_dependency(
+        db,
+        dependency_id,
+    )
+
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Species dependency not found",
+        )
+
+    return
+
+
+router.include_router(exclusion_rules_router)
+router.include_router(dependencies_router)

--- a/backend/src/schemas/exclusion_rules.py
+++ b/backend/src/schemas/exclusion_rules.py
@@ -1,18 +1,38 @@
-from typing import List, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class SpeciesExclusionRuleBase(BaseModel):
-    feature: str = Field(..., description="The farm feature to check (e.g., 'ph', 'rainfall_mm', 'soil_texture')")
-    operator: str = Field(..., description="The logical operator: '<', '>', '==', '!=', 'in_set', 'not_in_set'")
+    feature: str = Field(
+        ...,
+        description="The farm feature to check (e.g., 'ph', 'rainfall_mm', 'soil_texture')",
+    )
+    operator: Literal["<", ">", "<=", ">=", "==", "!=", "in_set", "not_in_set"] = Field(
+        ...,
+        description="The comparison operator used by the exclusion engine",
+    )
     # Union allows the JSON column to accept diverse types
-    value: Union[float, str, List[str]] = Field(..., description="The threshold value (number, single string, or list of strings)")
-    reason: str = Field(..., description="The narrative reason for exclusion (e.g., 'elevation is too high')")
+    value: Union[float, str, List[str]] = Field(
+        ...,
+        description="The threshold value (number, single string, or list of strings)",
+    )
+    reason: str = Field(
+        ...,
+        description="The narrative reason for exclusion (e.g., 'elevation is too high')",
+    )
 
 
 class SpeciesExclusionRuleCreate(SpeciesExclusionRuleBase):
-    species_id: int
+    species_id: int = Field(..., gt=0)
+
+
+class SpeciesExclusionRuleUpdate(BaseModel):
+    species_id: Optional[int] = Field(default=None, gt=0)
+    feature: Optional[str] = Field(default=None, min_length=1)
+    operator: Optional[Literal["<", ">", "<=", ">=", "==", "!=", "in_set", "not_in_set"]] = None
+    value: Optional[Union[float, str, List[str]]] = None
+    reason: Optional[str] = Field(default=None, min_length=1)
 
 
 class SpeciesExclusionRuleRead(SpeciesExclusionRuleBase):
@@ -23,14 +43,19 @@ class SpeciesExclusionRuleRead(SpeciesExclusionRuleBase):
 
 
 class SpeciesDependencyBase(BaseModel):
-    focal_species_id: int
-    required_partner_id: int
+    focal_species_id: int = Field(..., gt=0)
+    required_partner_id: int = Field(..., gt=0)
 
 
 class SpeciesDependencyCreate(SpeciesDependencyBase):
     """No extra fields needed, but separates creation from reading."""
 
     pass
+
+
+class SpeciesDependencyUpdate(BaseModel):
+    focal_species_id: Optional[int] = Field(default=None, gt=0)
+    required_partner_id: Optional[int] = Field(default=None, gt=0)
 
 
 class SpeciesDependencyRead(SpeciesDependencyBase):

--- a/backend/src/services/exclusion_rules.py
+++ b/backend/src/services/exclusion_rules.py
@@ -1,0 +1,181 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.exclusion_rules import SpeciesDependency, SpeciesExclusionRule
+from src.models.species import Species
+from src.schemas.exclusion_rules import (
+    SpeciesDependencyCreate,
+    SpeciesDependencyUpdate,
+    SpeciesExclusionRuleCreate,
+    SpeciesExclusionRuleUpdate,
+)
+
+
+async def _validate_species_exists(db: AsyncSession, species_id: int) -> None:
+    result = await db.execute(select(Species.id).where(Species.id == species_id))
+    if result.scalar_one_or_none() is None:
+        raise ValueError(f"Species with id {species_id} not found")
+
+
+async def _validate_dependency(
+    db: AsyncSession,
+    focal_species_id: int,
+    required_partner_id: int,
+) -> None:
+    if focal_species_id == required_partner_id:
+        raise ValueError("A species cannot depend on itself")
+
+    await _validate_species_exists(db, focal_species_id)
+    await _validate_species_exists(db, required_partner_id)
+
+
+async def get_all_exclusion_rules(
+    db: AsyncSession,
+) -> list[SpeciesExclusionRule]:
+    result = await db.execute(select(SpeciesExclusionRule).order_by(SpeciesExclusionRule.id))
+    return list(result.scalars().all())
+
+
+async def get_exclusion_rule_by_id(
+    db: AsyncSession,
+    rule_id: int,
+) -> SpeciesExclusionRule | None:
+    result = await db.execute(select(SpeciesExclusionRule).where(SpeciesExclusionRule.id == rule_id))
+    return result.scalar_one_or_none()
+
+
+async def create_exclusion_rule(
+    db: AsyncSession,
+    payload: SpeciesExclusionRuleCreate,
+) -> SpeciesExclusionRule:
+    await _validate_species_exists(db, payload.species_id)
+
+    rule = SpeciesExclusionRule(**payload.model_dump())
+    db.add(rule)
+    await db.commit()
+    await db.refresh(rule)
+    return rule
+
+
+async def update_exclusion_rule(
+    db: AsyncSession,
+    rule_id: int,
+    payload: SpeciesExclusionRuleUpdate,
+) -> SpeciesExclusionRule | None:
+    rule = await get_exclusion_rule_by_id(db, rule_id)
+
+    if rule is None:
+        return None
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if any(value is None for value in update_data.values()):
+        raise ValueError("Exclusion rule fields cannot be null")
+
+    if "species_id" in update_data:
+        await _validate_species_exists(db, update_data["species_id"])
+
+    for field, value in update_data.items():
+        setattr(rule, field, value)
+
+    await db.commit()
+    await db.refresh(rule)
+    return rule
+
+
+async def delete_exclusion_rule(
+    db: AsyncSession,
+    rule_id: int,
+) -> bool:
+    rule = await get_exclusion_rule_by_id(db, rule_id)
+
+    if rule is None:
+        return False
+
+    await db.delete(rule)
+    await db.commit()
+    return True
+
+
+async def get_all_dependencies(
+    db: AsyncSession,
+) -> list[SpeciesDependency]:
+    result = await db.execute(select(SpeciesDependency).order_by(SpeciesDependency.id))
+    return list(result.scalars().all())
+
+
+async def get_dependency_by_id(
+    db: AsyncSession,
+    dependency_id: int,
+) -> SpeciesDependency | None:
+    result = await db.execute(select(SpeciesDependency).where(SpeciesDependency.id == dependency_id))
+    return result.scalar_one_or_none()
+
+
+async def create_dependency(
+    db: AsyncSession,
+    payload: SpeciesDependencyCreate,
+) -> SpeciesDependency:
+    await _validate_dependency(
+        db,
+        payload.focal_species_id,
+        payload.required_partner_id,
+    )
+
+    dependency = SpeciesDependency(**payload.model_dump())
+    db.add(dependency)
+    await db.commit()
+    await db.refresh(dependency)
+    return dependency
+
+
+async def update_dependency(
+    db: AsyncSession,
+    dependency_id: int,
+    payload: SpeciesDependencyUpdate,
+) -> SpeciesDependency | None:
+    dependency = await get_dependency_by_id(db, dependency_id)
+
+    if dependency is None:
+        return None
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if any(value is None for value in update_data.values()):
+        raise ValueError("Dependency fields cannot be null")
+
+    focal_species_id = update_data.get(
+        "focal_species_id",
+        dependency.focal_species_id,
+    )
+    required_partner_id = update_data.get(
+        "required_partner_id",
+        dependency.required_partner_id,
+    )
+
+    await _validate_dependency(
+        db,
+        focal_species_id,
+        required_partner_id,
+    )
+
+    for field, value in update_data.items():
+        setattr(dependency, field, value)
+
+    await db.commit()
+    await db.refresh(dependency)
+    return dependency
+
+
+async def delete_dependency(
+    db: AsyncSession,
+    dependency_id: int,
+) -> bool:
+    dependency = await get_dependency_by_id(db, dependency_id)
+
+    if dependency is None:
+        return False
+
+    await db.delete(dependency)
+    await db.commit()
+    return True

--- a/backend/tests/test_exclusion_rules_router.py
+++ b/backend/tests/test_exclusion_rules_router.py
@@ -1,0 +1,541 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.species import Species
+
+
+async def add_species(
+    async_session: AsyncSession,
+    suffix: str,
+) -> Species:
+    species = Species(
+        name=f"US031 Species {suffix}",
+        common_name=f"US031 Common {suffix}",
+        rainfall_mm_min=500,
+        rainfall_mm_max=3000,
+        temperature_celsius_min=15,
+        temperature_celsius_max=35,
+        elevation_m_min=0,
+        elevation_m_max=2000,
+        ph_min=5.0,
+        ph_max=8.0,
+        coastal=False,
+        riparian=False,
+        nitrogen_fixing=False,
+        shade_tolerant=False,
+        bank_stabilising=False,
+    )
+    async_session.add(species)
+    await async_session.flush()
+    await async_session.refresh(species)
+    return species
+
+
+async def test_exclusion_rule_crud(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    species = await add_species(async_session, "Rule CRUD")
+
+    create_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": species.id,
+            "feature": "ph",
+            "operator": "<",
+            "value": 5.5,
+            "reason": "Soil pH is too low",
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()
+    rule_id = created["id"]
+    assert created["species_id"] == species.id
+    assert created["feature"] == "ph"
+    assert created["operator"] == "<"
+    assert created["value"] == pytest.approx(5.5)
+
+    get_response = await async_client.get(
+        f"/exclusion-rules/{rule_id}",
+        headers=admin_auth_headers,
+    )
+
+    assert get_response.status_code == 200
+    assert get_response.json()["id"] == rule_id
+
+    list_response = await async_client.get(
+        "/exclusion-rules",
+        headers=admin_auth_headers,
+    )
+
+    assert list_response.status_code == 200
+    listed_rules = list_response.json()
+    assert any(rule["id"] == rule_id for rule in listed_rules)
+    listed_ids = [rule["id"] for rule in listed_rules]
+    assert listed_ids == sorted(listed_ids)
+
+    update_response = await async_client.patch(
+        f"/exclusion-rules/{rule_id}",
+        json={
+            "operator": "<=",
+            "value": 6.0,
+            "reason": "Updated pH requirement",
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["operator"] == "<="
+    assert updated["value"] == pytest.approx(6.0)
+    assert updated["reason"] == "Updated pH requirement"
+    assert updated["feature"] == "ph"
+
+    delete_response = await async_client.delete(
+        f"/exclusion-rules/{rule_id}",
+        headers=admin_auth_headers,
+    )
+
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
+
+    deleted_get_response = await async_client.get(
+        f"/exclusion-rules/{rule_id}",
+        headers=admin_auth_headers,
+    )
+    assert deleted_get_response.status_code == 404
+
+
+async def test_exclusion_rules_require_admin(
+    async_client: AsyncClient,
+    officer_auth_headers: dict,
+):
+    unauthenticated_response = await async_client.get("/exclusion-rules")
+    assert unauthenticated_response.status_code == 401
+
+    forbidden_response = await async_client.get(
+        "/exclusion-rules",
+        headers=officer_auth_headers,
+    )
+    assert forbidden_response.status_code == 403
+
+    forbidden_create_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": 1,
+            "feature": "ph",
+            "operator": "<",
+            "value": 5.5,
+            "reason": "Not authorised",
+        },
+        headers=officer_auth_headers,
+    )
+    assert forbidden_create_response.status_code == 403
+
+
+async def test_create_exclusion_rule_rejects_invalid_species(
+    async_client: AsyncClient,
+    admin_auth_headers: dict,
+):
+    response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": 999999,
+            "feature": "ph",
+            "operator": "<",
+            "value": 5.5,
+            "reason": "Invalid species",
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert "not found" in response.json()["detail"]
+
+
+async def test_create_exclusion_rule_rejects_invalid_input(
+    async_client: AsyncClient,
+    admin_auth_headers: dict,
+):
+    invalid_operator_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": 1,
+            "feature": "ph",
+            "operator": "invalid_operator",
+            "value": 5.5,
+            "reason": "Invalid operator",
+        },
+        headers=admin_auth_headers,
+    )
+    assert invalid_operator_response.status_code == 422
+
+    invalid_id_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": 0,
+            "feature": "ph",
+            "operator": "<",
+            "value": 5.5,
+            "reason": "Invalid ID",
+        },
+        headers=admin_auth_headers,
+    )
+    assert invalid_id_response.status_code == 422
+
+
+async def test_update_exclusion_rule_rejects_null(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    species = await add_species(async_session, "Null Update")
+
+    create_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": species.id,
+            "feature": "rainfall_mm",
+            "operator": "<",
+            "value": 700,
+            "reason": "Insufficient rainfall",
+        },
+        headers=admin_auth_headers,
+    )
+    assert create_response.status_code == 201
+
+    rule_id = create_response.json()["id"]
+    response = await async_client.patch(
+        f"/exclusion-rules/{rule_id}",
+        json={"reason": None},
+        headers=admin_auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Exclusion rule fields cannot be null"
+
+
+async def test_exclusion_rule_not_found_responses(
+    async_client: AsyncClient,
+    admin_auth_headers: dict,
+):
+    get_response = await async_client.get(
+        "/exclusion-rules/999999",
+        headers=admin_auth_headers,
+    )
+    assert get_response.status_code == 404
+    assert get_response.json()["detail"] == "Exclusion rule not found"
+
+    update_response = await async_client.patch(
+        "/exclusion-rules/999999",
+        json={"reason": "Missing rule"},
+        headers=admin_auth_headers,
+    )
+    assert update_response.status_code == 404
+
+    delete_response = await async_client.delete(
+        "/exclusion-rules/999999",
+        headers=admin_auth_headers,
+    )
+    assert delete_response.status_code == 404
+
+
+async def test_species_dependency_crud(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    focal_species = await add_species(async_session, "Dependency Focal")
+    first_partner = await add_species(async_session, "Dependency Partner One")
+    second_partner = await add_species(async_session, "Dependency Partner Two")
+
+    create_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": focal_species.id,
+            "required_partner_id": first_partner.id,
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()
+    dependency_id = created["id"]
+    assert created["focal_species_id"] == focal_species.id
+    assert created["required_partner_id"] == first_partner.id
+
+    get_response = await async_client.get(
+        f"/species-dependencies/{dependency_id}",
+        headers=admin_auth_headers,
+    )
+
+    assert get_response.status_code == 200
+    assert get_response.json()["id"] == dependency_id
+
+    list_response = await async_client.get(
+        "/species-dependencies",
+        headers=admin_auth_headers,
+    )
+
+    assert list_response.status_code == 200
+    listed_dependencies = list_response.json()
+    assert any(dependency["id"] == dependency_id for dependency in listed_dependencies)
+    listed_ids = [dependency["id"] for dependency in listed_dependencies]
+    assert listed_ids == sorted(listed_ids)
+
+    update_response = await async_client.patch(
+        f"/species-dependencies/{dependency_id}",
+        json={"required_partner_id": second_partner.id},
+        headers=admin_auth_headers,
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["focal_species_id"] == focal_species.id
+    assert updated["required_partner_id"] == second_partner.id
+
+    delete_response = await async_client.delete(
+        f"/species-dependencies/{dependency_id}",
+        headers=admin_auth_headers,
+    )
+
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
+
+    deleted_get_response = await async_client.get(
+        f"/species-dependencies/{dependency_id}",
+        headers=admin_auth_headers,
+    )
+    assert deleted_get_response.status_code == 404
+
+
+async def test_species_dependencies_require_admin(
+    async_client: AsyncClient,
+    officer_auth_headers: dict,
+):
+    unauthenticated_response = await async_client.get("/species-dependencies")
+    assert unauthenticated_response.status_code == 401
+
+    forbidden_response = await async_client.get(
+        "/species-dependencies",
+        headers=officer_auth_headers,
+    )
+    assert forbidden_response.status_code == 403
+
+    forbidden_create_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": 1,
+            "required_partner_id": 2,
+        },
+        headers=officer_auth_headers,
+    )
+    assert forbidden_create_response.status_code == 403
+
+
+async def test_create_dependency_rejects_missing_species(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    existing_species = await add_species(
+        async_session,
+        "Dependency Existing",
+    )
+
+    missing_focal_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": 999998,
+            "required_partner_id": existing_species.id,
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert missing_focal_response.status_code == 422
+    assert "not found" in missing_focal_response.json()["detail"]
+
+    missing_partner_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": existing_species.id,
+            "required_partner_id": 999999,
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert missing_partner_response.status_code == 422
+    assert "not found" in missing_partner_response.json()["detail"]
+
+
+async def test_create_dependency_rejects_self_dependency(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    species = await add_species(async_session, "Self Dependency")
+
+    response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": species.id,
+            "required_partner_id": species.id,
+        },
+        headers=admin_auth_headers,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "A species cannot depend on itself"
+
+
+async def test_dependency_rejects_invalid_id_and_null_update(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    focal_species = await add_species(async_session, "Invalid Update Focal")
+    partner_species = await add_species(
+        async_session,
+        "Invalid Update Partner",
+    )
+
+    invalid_id_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": 0,
+            "required_partner_id": partner_species.id,
+        },
+        headers=admin_auth_headers,
+    )
+    assert invalid_id_response.status_code == 422
+
+    create_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": focal_species.id,
+            "required_partner_id": partner_species.id,
+        },
+        headers=admin_auth_headers,
+    )
+    assert create_response.status_code == 201
+
+    dependency_id = create_response.json()["id"]
+    null_update_response = await async_client.patch(
+        f"/species-dependencies/{dependency_id}",
+        json={"required_partner_id": None},
+        headers=admin_auth_headers,
+    )
+
+    assert null_update_response.status_code == 422
+    assert null_update_response.json()["detail"] == "Dependency fields cannot be null"
+
+
+async def test_update_dependency_rejects_invalid_relationship(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    focal_species = await add_species(async_session, "Update Focal")
+    partner_species = await add_species(async_session, "Update Partner")
+
+    create_response = await async_client.post(
+        "/species-dependencies",
+        json={
+            "focal_species_id": focal_species.id,
+            "required_partner_id": partner_species.id,
+        },
+        headers=admin_auth_headers,
+    )
+    assert create_response.status_code == 201
+
+    dependency_id = create_response.json()["id"]
+
+    self_dependency_response = await async_client.patch(
+        f"/species-dependencies/{dependency_id}",
+        json={"required_partner_id": focal_species.id},
+        headers=admin_auth_headers,
+    )
+    assert self_dependency_response.status_code == 422
+    assert self_dependency_response.json()["detail"] == "A species cannot depend on itself"
+
+    missing_species_response = await async_client.patch(
+        f"/species-dependencies/{dependency_id}",
+        json={"required_partner_id": 999999},
+        headers=admin_auth_headers,
+    )
+    assert missing_species_response.status_code == 422
+    assert "not found" in missing_species_response.json()["detail"]
+
+
+async def test_species_dependency_not_found_responses(
+    async_client: AsyncClient,
+    admin_auth_headers: dict,
+):
+    get_response = await async_client.get(
+        "/species-dependencies/999999",
+        headers=admin_auth_headers,
+    )
+    assert get_response.status_code == 404
+    assert get_response.json()["detail"] == "Species dependency not found"
+
+    update_response = await async_client.patch(
+        "/species-dependencies/999999",
+        json={"required_partner_id": 1},
+        headers=admin_auth_headers,
+    )
+    assert update_response.status_code == 404
+
+    delete_response = await async_client.delete(
+        "/species-dependencies/999999",
+        headers=admin_auth_headers,
+    )
+    assert delete_response.status_code == 404
+
+
+async def test_update_exclusion_rule_validates_species(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+    admin_auth_headers: dict,
+):
+    original_species = await add_species(async_session, "Original Rule Species")
+    replacement_species = await add_species(
+        async_session,
+        "Replacement Rule Species",
+    )
+
+    create_response = await async_client.post(
+        "/exclusion-rules",
+        json={
+            "species_id": original_species.id,
+            "feature": "ph",
+            "operator": "<",
+            "value": 5.5,
+            "reason": "Soil pH is too low",
+        },
+        headers=admin_auth_headers,
+    )
+    assert create_response.status_code == 201
+
+    rule_id = create_response.json()["id"]
+
+    valid_update_response = await async_client.patch(
+        f"/exclusion-rules/{rule_id}",
+        json={"species_id": replacement_species.id},
+        headers=admin_auth_headers,
+    )
+
+    assert valid_update_response.status_code == 200
+    assert valid_update_response.json()["species_id"] == replacement_species.id
+
+    missing_species_response = await async_client.patch(
+        f"/exclusion-rules/{rule_id}",
+        json={"species_id": 999999},
+        headers=admin_auth_headers,
+    )
+
+    assert missing_species_response.status_code == 422
+    assert "not found" in missing_species_response.json()["detail"]


### PR DESCRIPTION
## Description
Implements admin-only CRUD APIs for species exclusion rules and species dependencies.

This PR:

- Adds list, get, create, patch and delete endpoints for both resources
- Adds create and update schema validation
- Restricts all endpoints to ADMIN users
- Validates that referenced species exist
- Prevents a species from depending on itself
- Returns stable database ordering
- Handles 201, 204, 404 and 422 responses
- Registers the new router in main.py
- Adds tests for CRUD, authentication, authorisation, validation and missing records


## Related Issue / Task
Closes  #239 #325 


## Team / Area
<!-- Indicate which part of the project this PR affects. For example: -->
- [ ] Frontend
- [x] Backend
- [ ] Data Science
- [ ] GIS
- [ ] Documentation
- [ ] Other (please specify):

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / maintenance
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the project’s style guidelines (linting & formatting)
- [x] This PR is based on the latest `upstream/master`
- [x] I have updated documentation if necessary

## Additional Notes
Validation completed successfully:

- 14 focused US-031 tests passed
- 325 full backend tests passed
- 92% total backend coverage
- New schema, service and router files have 100% coverage
- Ruff lint and formatting checks passed
- 487 frontend tests passed during the pre-commit hook

No migrations were required because the existing database models were reused.
